### PR TITLE
Fix data environment SQL routing

### DIFF
--- a/runtime/modules/sql/Framework/DB.php
+++ b/runtime/modules/sql/Framework/DB.php
@@ -887,16 +887,15 @@ final class DB {
 	/**
 	 * Normalizes optional cluster names before creating SQL contexts.
 	 *
-	 * blank strings collapse to null so transaction and connection helpers
-	 * can consistently fall back to default-cluster behavior instead of carrying an
-	 * invalid empty cluster identifier into the SQL kernel.
+	 * Null or blank names inherit the active data environment cluster, then fall
+	 * back to ordinary default-cluster behavior when no environment is active.
+	 * Explicit non-empty names remain authoritative.
 	 */
 	private static function normalizeCluster(?string $cluster): ?string {
-		if($cluster===null){
-			return null;
+		if($cluster===null || trim($cluster)===''){
+			return DataEnvironment::clusterOverride();
 		}
-		$cluster=trim($cluster);
-		return $cluster!=='' ? $cluster : null;
+		return trim($cluster);
 	}
 
 	/**

--- a/runtime/modules/sql/Framework/TableDefinition.php
+++ b/runtime/modules/sql/Framework/TableDefinition.php
@@ -601,8 +601,8 @@ final class TableDefinition {
 	 * Executes schema creation queries for this table definition.
 	 *
 	 * Required create-schema/create-table queries must succeed; optional index queries
-	 * are attempted after table creation. The table cluster override is read from
-	 * DP_SQL_CFG.
+	 * are attempted after table creation. An active data environment takes precedence
+	 * over the table's ordinary cluster so sandbox hydration cannot mutate live schema.
 	 *
 	 * @return bool True when required hydration queries succeed.
 	 */
@@ -611,7 +611,7 @@ final class TableDefinition {
 		if($queries===[]){
 			return false;
 		}
-		$dbmsCluster=\DP_SQL_CFG['tables'][$this->table]['cluster'] ?? \DP_SQL_CFG['default_cluster'];
+		$dbmsCluster=$this->hydrationCluster();
 		foreach($queries as $index=>$query){
 			$required=(bool)($query['_required'] ?? $index===0);
 			$query['dbms_cluster_override']=$dbmsCluster;
@@ -638,7 +638,7 @@ final class TableDefinition {
 		if(!isset($this->columns[$column]) || $this->columns[$column]['inline_primary']===true){
 			return false;
 		}
-		$dbmsCluster=\DP_SQL_CFG['tables'][$this->table]['cluster'] ?? \DP_SQL_CFG['default_cluster'];
+		$dbmsCluster=$this->hydrationCluster();
 		$query=[
 			'mysql'=>'ALTER TABLE '.$this->quoteTable('mysql').' ADD COLUMN '.$this->columnSql($this->columns[$column], 'mysql'),
 			'postgresql'=>'ALTER TABLE '.$this->quoteTable('postgresql').' ADD COLUMN IF NOT EXISTS '.$this->columnSql($this->columns[$column], 'postgresql'),
@@ -656,6 +656,17 @@ final class TableDefinition {
 			return true;
 		}
 		return false;
+	}
+
+	/** Resolves schema changes through the active data environment before defaults. */
+	private function hydrationCluster(): string {
+		$environmentCluster=class_exists(DataEnvironment::class)
+			? DataEnvironment::clusterOverride()
+			: null;
+		if($environmentCluster!==null){
+			return $environmentCluster;
+		}
+		return (string)(\DP_SQL_CFG['tables'][$this->table]['cluster'] ?? \DP_SQL_CFG['default_cluster']);
 	}
 
 	/**

--- a/runtime/modules/sql/kernel/mysql_query.php
+++ b/runtime/modules/sql/kernel/mysql_query.php
@@ -270,6 +270,83 @@ class mysql_query_builder {
 		}
 		return $query_list;
 	}
+
+	/**
+	 * Resolves the immutable data environment captured when a query was queued.
+	 *
+	 * Explicit non-empty cluster metadata is already resolved by the SQL kernel
+	 * and must not be passed through the ambient cluster resolver again. Legacy
+	 * payloads without a snapshot retain the environment active when drained.
+	 *
+	 * @param array<string, mixed> $query_info Queued query metadata.
+	 * @return array{name:string,cluster:string,cache_namespace:?string,captured:bool,active:bool}
+	 */
+	private static function queued_environment(array $query_info): array {
+		$current=[
+			'name'=>'live',
+			'cluster'=>null,
+			'cache_namespace'=>null,
+		];
+		if(class_exists('\\Dataphyre\\Database\\DataEnvironment')){
+			$current=\Dataphyre\Database\DataEnvironment::current();
+		}
+		$captured=is_array($query_info['data_environment'] ?? null);
+		$snapshot=$captured
+			? $query_info['data_environment']
+			: [];
+		$name=strtolower(trim((string)($snapshot['name'] ?? $current['name'] ?? 'live')));
+		if($name==='' || preg_match('/^[a-z0-9][a-z0-9._-]*$/D', $name)!==1){
+			$name='live';
+		}
+		$cluster='';
+		foreach([
+			$query_info['dbms_cluster'] ?? null,
+			$snapshot['cluster'] ?? null,
+			$current['cluster'] ?? null,
+			DP_SQL_CFG['tables']['raw']['cluster'] ?? DP_SQL_CFG['default_cluster'] ?? '',
+		] as $candidate){
+			if(!is_string($candidate) || trim($candidate)===''){
+				continue;
+			}
+			$cluster=trim($candidate);
+			break;
+		}
+		$namespace=array_key_exists('cache_namespace', $snapshot)
+			? $snapshot['cache_namespace']
+			: ($current['cache_namespace'] ?? null);
+		$namespace=is_string($namespace) && trim($namespace)!=='' ? trim($namespace) : null;
+		$active=$captured
+			? (bool)($snapshot['active'] ?? true)
+			: (class_exists('\\Dataphyre\\Database\\DataEnvironment') && \Dataphyre\Database\DataEnvironment::active());
+		return [
+			'name'=>$name,
+			'cluster'=>$cluster,
+			'cache_namespace'=>$namespace,
+			'captured'=>$captured,
+			'active'=>$active,
+		];
+	}
+
+	/** Runs execution and result side effects inside a captured data environment. */
+	private static function run_in_queued_environment(array $environment, callable $callback): mixed {
+		if(
+			($environment['captured'] ?? false)!==true
+			|| !class_exists('\\Dataphyre\\Database\\DataEnvironment')
+		){
+			return $callback();
+		}
+		if(($environment['active'] ?? true)!==true && !\Dataphyre\Database\DataEnvironment::active()){
+			return $callback();
+		}
+		return \Dataphyre\Database\DataEnvironment::run(
+			(string)$environment['name'],
+			static fn(): mixed=>$callback(),
+			[
+				'cluster'=>(string)$environment['cluster'],
+				'cache_namespace'=>$environment['cache_namespace'],
+			]
+		);
+	}
 	
 	/**
 	 * Executes and clears one queued MySQL query batch.
@@ -287,13 +364,56 @@ class mysql_query_builder {
 		if(!isset(self::$queued_queries[$queue]))return null;
 		$queued_queries=self::$queued_queries[$queue];
 		unset(self::$queued_queries[$queue]);
+		$batches=[];
+		foreach(self::queued_query_list($queued_queries) as $query_info){
+			$environment=self::queued_environment($query_info);
+			$batch_index=array_key_last($batches);
+			if($batch_index===null || $batches[$batch_index]['environment']!==$environment){
+				$batches[]=[
+					'environment'=>$environment,
+					'queries'=>[],
+				];
+				$batch_index=array_key_last($batches);
+			}
+			$batches[$batch_index]['queries'][]=$query_info;
+		}
+		$success=true;
+		foreach($batches as $batch){
+			$result=self::run_in_queued_environment(
+				$batch['environment'],
+				static fn(): bool=>self::execute_multiquery_batch(
+					$queue,
+					$batch['queries'],
+					(string)$batch['environment']['cluster'],
+					$hydration_retry
+				)
+			);
+			if($result!==true){
+				$success=false;
+			}
+		}
+		return $success;
+	}
+
+	/**
+	 * Executes one cluster-homogeneous MySQL queue batch.
+	 *
+	 * @param list<array<string,mixed>> $queued_queries Queries in the best order
+	 *        recoverable from the legacy type-grouped queue representation.
+	 */
+	private static function execute_multiquery_batch(
+		string $queue,
+		array $queued_queries,
+		string $dbms_cluster,
+		bool $hydration_retry
+	): bool {
 		$multipoint=false;
 		$queries=[];
 		$prepared_statements=[];
 		$multi_query_string="";
 		$index=0;
-		foreach($queued_queries as $query_type=>$query_info_array){
-			foreach($query_info_array as $query_info){
+		foreach($queued_queries as $query_info){
+				$query_type=trim((string)($query_info['type'] ?? 'raw')) ?: 'raw';
 				switch($query_type){
 					case 'select':
 						$query_info['query']="SELECT {$query_info['select']} FROM {$query_info['location']} {$query_info['params']}";
@@ -325,17 +445,15 @@ class mysql_query_builder {
 				$query_info['type']=$query_type;
 				$queries[$index]=$query_info;
 				$index++;
-			}
 		}
 		$results=[];
-		$dbms_cluster=DP_SQL_CFG['tables']['raw']['cluster'] ?? DP_SQL_CFG['default_cluster'];
 		if($multipoint===true){
 			$endpoints=DP_SQL_CFG['datacenters'][DP_CORE_CFG['datacenter']]['dbms_clusters'][$dbms_cluster]['endpoints'];
 			if(!empty($prepared_statements)){
 				foreach($endpoints as $endpoint){
 					$conn=self::connect_to_endpoint($endpoint, $dbms_cluster);
 					if(!self::execute_prepared_statements($conn, $prepared_statements, $results, $dbms_cluster)){
-						return self::retry_queue_after_hydration($queue, $queued_queries, $hydration_retry);
+						return self::retry_batch_after_hydration($queue, $queued_queries, $dbms_cluster, $hydration_retry);
 					}
 				}
 			}
@@ -344,7 +462,7 @@ class mysql_query_builder {
 				foreach($endpoints as $endpoint){
 					$conn=self::connect_to_endpoint($endpoint, $dbms_cluster);
 					if(!self::execute_multi_query_string($conn, $multi_query_string, $results, $dbms_cluster)){
-						return self::retry_queue_after_hydration($queue, $queued_queries, $hydration_retry);
+						return self::retry_batch_after_hydration($queue, $queued_queries, $dbms_cluster, $hydration_retry);
 					}
 				}
 			}
@@ -354,13 +472,13 @@ class mysql_query_builder {
 			self::connect_to_cluster($dbms_cluster);
 			if(!empty($prepared_statements)){
 				if(!self::execute_prepared_statements(self::$conns[$dbms_cluster], $prepared_statements, $results, $dbms_cluster)){
-					return self::retry_queue_after_hydration($queue, $queued_queries, $hydration_retry);
+					return self::retry_batch_after_hydration($queue, $queued_queries, $dbms_cluster, $hydration_retry);
 				}
 			}
 			else
 			{
 				if(!self::execute_multi_query_string(self::$conns[$dbms_cluster], $multi_query_string, $results, $dbms_cluster)){
-					return self::retry_queue_after_hydration($queue, $queued_queries, $hydration_retry);
+					return self::retry_batch_after_hydration($queue, $queued_queries, $dbms_cluster, $hydration_retry);
 				}
 			}
 		}
@@ -369,20 +487,34 @@ class mysql_query_builder {
 	}
 
 	/**
-	 * Requeues a failed batch after attempting schema hydration once.
+	 * Retries a failed captured batch after attempting schema hydration once.
 	 *
 	 * @param string $queue Queue name that failed.
-	 * @param array<string, mixed> $queued_queries Original queued query payload.
+	 * @param list<array<string, mixed>> $queued_queries Original captured batch.
 	 * @param bool $hydration_retry Whether the caller is already in a hydration retry.
 	 * @return bool `true` when the retry completed successfully.
 	 */
+	private static function retry_batch_after_hydration(
+		string $queue,
+		array $queued_queries,
+		string $dbms_cluster,
+		bool $hydration_retry
+	): bool {
+		if($hydration_retry===true || sql::hydrate_missing_structure_from_definition()===false){
+			return false;
+		}
+		sql::clear_last_query_error();
+		return self::execute_multiquery_batch($queue, $queued_queries, $dbms_cluster, true);
+	}
+
+	/** Preserves the legacy grouped-queue hydration retry seam. */
 	private static function retry_queue_after_hydration(string $queue, array $queued_queries, bool $hydration_retry): bool {
 		if($hydration_retry===true || sql::hydrate_missing_structure_from_definition()===false){
 			return false;
 		}
 		self::$queued_queries[$queue]=$queued_queries;
 		sql::clear_last_query_error();
-		return self::execute_multiquery($queue, true) === true;
+		return self::execute_multiquery($queue, true)===true;
 	}
 	
 	/**

--- a/runtime/modules/sql/kernel/postgresql_query.php
+++ b/runtime/modules/sql/kernel/postgresql_query.php
@@ -245,8 +245,13 @@ class postgresql_query_builder {
 							throw new \Exception("Query failed: ".pg_last_error($conn));
 						}
 						$fetched_results=pg_fetch_all($result, PGSQL_ASSOC);
-						self::normalize_pg_value($fetched_results, $result);
-						$results[$index]=$fetched_results?$fetched_results:[];
+						if($fetched_results!==false){
+							foreach($fetched_results as &$row){
+								self::normalize_pg_value($row, $result);
+							}
+							unset($row);
+						}
+						$results[$index]=$fetched_results ?: [];
 						pg_free_result($result);
 					}
 					$index++;
@@ -341,6 +346,83 @@ class postgresql_query_builder {
 		}
 		return $query_list;
 	}
+
+	/**
+	 * Resolves the immutable data environment captured when a query was queued.
+	 *
+	 * Explicit non-empty cluster metadata is already resolved by the SQL kernel
+	 * and must not be passed through the ambient cluster resolver again. Legacy
+	 * payloads without a snapshot retain the environment active when drained.
+	 *
+	 * @param array<string, mixed> $query_info Queued query metadata.
+	 * @return array{name:string,cluster:string,cache_namespace:?string,captured:bool,active:bool}
+	 */
+	private static function queued_environment(array $query_info): array {
+		$current=[
+			'name'=>'live',
+			'cluster'=>null,
+			'cache_namespace'=>null,
+		];
+		if(class_exists('\\Dataphyre\\Database\\DataEnvironment')){
+			$current=\Dataphyre\Database\DataEnvironment::current();
+		}
+		$captured=is_array($query_info['data_environment'] ?? null);
+		$snapshot=$captured
+			? $query_info['data_environment']
+			: [];
+		$name=strtolower(trim((string)($snapshot['name'] ?? $current['name'] ?? 'live')));
+		if($name==='' || preg_match('/^[a-z0-9][a-z0-9._-]*$/D', $name)!==1){
+			$name='live';
+		}
+		$cluster='';
+		foreach([
+			$query_info['dbms_cluster'] ?? null,
+			$snapshot['cluster'] ?? null,
+			$current['cluster'] ?? null,
+			DP_SQL_CFG['tables']['raw']['cluster'] ?? DP_SQL_CFG['default_cluster'] ?? '',
+		] as $candidate){
+			if(!is_string($candidate) || trim($candidate)===''){
+				continue;
+			}
+			$cluster=trim($candidate);
+			break;
+		}
+		$namespace=array_key_exists('cache_namespace', $snapshot)
+			? $snapshot['cache_namespace']
+			: ($current['cache_namespace'] ?? null);
+		$namespace=is_string($namespace) && trim($namespace)!=='' ? trim($namespace) : null;
+		$active=$captured
+			? (bool)($snapshot['active'] ?? true)
+			: (class_exists('\\Dataphyre\\Database\\DataEnvironment') && \Dataphyre\Database\DataEnvironment::active());
+		return [
+			'name'=>$name,
+			'cluster'=>$cluster,
+			'cache_namespace'=>$namespace,
+			'captured'=>$captured,
+			'active'=>$active,
+		];
+	}
+
+	/** Runs execution and result side effects inside a captured data environment. */
+	private static function run_in_queued_environment(array $environment, callable $callback): mixed {
+		if(
+			($environment['captured'] ?? false)!==true
+			|| !class_exists('\\Dataphyre\\Database\\DataEnvironment')
+		){
+			return $callback();
+		}
+		if(($environment['active'] ?? true)!==true && !\Dataphyre\Database\DataEnvironment::active()){
+			return $callback();
+		}
+		return \Dataphyre\Database\DataEnvironment::run(
+			(string)$environment['name'],
+			static fn(): mixed=>$callback(),
+			[
+				'cluster'=>(string)$environment['cluster'],
+				'cache_namespace'=>$environment['cache_namespace'],
+			]
+		);
+	}
 	
 	/**
 	 * Executes and clears one queued PostgreSQL query batch.
@@ -358,13 +440,56 @@ class postgresql_query_builder {
 		if(!isset(self::$queued_queries[$queue]))return null;
 		$queued_queries=self::$queued_queries[$queue];
 		unset(self::$queued_queries[$queue]);
+		$batches=[];
+		foreach(self::queued_query_list($queued_queries) as $query_info){
+			$environment=self::queued_environment($query_info);
+			$batch_index=array_key_last($batches);
+			if($batch_index===null || $batches[$batch_index]['environment']!==$environment){
+				$batches[]=[
+					'environment'=>$environment,
+					'queries'=>[],
+				];
+				$batch_index=array_key_last($batches);
+			}
+			$batches[$batch_index]['queries'][]=$query_info;
+		}
+		$success=true;
+		foreach($batches as $batch){
+			$result=self::run_in_queued_environment(
+				$batch['environment'],
+				static fn(): bool=>self::execute_multiquery_batch(
+					$queue,
+					$batch['queries'],
+					(string)$batch['environment']['cluster'],
+					$hydration_retry
+				)
+			);
+			if($result!==true){
+				$success=false;
+			}
+		}
+		return $success;
+	}
+
+	/**
+	 * Executes one cluster-homogeneous PostgreSQL queue batch.
+	 *
+	 * @param list<array<string,mixed>> $queued_queries Queries in the best order
+	 *        recoverable from the legacy type-grouped queue representation.
+	 */
+	private static function execute_multiquery_batch(
+		string $queue,
+		array $queued_queries,
+		string $dbms_cluster,
+		bool $hydration_retry
+	): bool {
 		$multipoint=false;
 		$queries=[];
 		$prepared_statements=[];
 		$multi_query_string="";
 		$index=0;
-		foreach($queued_queries as $query_type=>$query_info_array){
-			foreach($query_info_array as $query_info){
+		foreach($queued_queries as $query_info){
+				$query_type=trim((string)($query_info['type'] ?? 'raw')) ?: 'raw';
 				switch($query_type){
 					case 'select':
 						$query_info['query']="SELECT {$query_info['select']} FROM {$query_info['location']} {$query_info['params']}";
@@ -394,17 +519,15 @@ class postgresql_query_builder {
 				$query_info['type']=$query_type;
 				$queries[$index]=$query_info;
 				$index++;
-			}
 		}
 		$results=[];
-		$dbms_cluster=DP_SQL_CFG['tables']['raw']['cluster'] ?? DP_SQL_CFG['default_cluster'];
 		if($multipoint===true){
 			$endpoints=DP_SQL_CFG['datacenters'][DP_CORE_CFG['datacenter']]['dbms_clusters'][$dbms_cluster]['endpoints'];
 			if(!empty($prepared_statements)){
 				foreach($endpoints as $endpoint){
 					$conn=self::connect_to_endpoint($endpoint, $dbms_cluster);
 					if(!self::execute_prepared_statements($conn, $prepared_statements, $results, $dbms_cluster)){
-						return self::retry_queue_after_hydration($queue, $queued_queries, $hydration_retry);
+						return self::retry_batch_after_hydration($queue, $queued_queries, $dbms_cluster, $hydration_retry);
 					}
 				}
 			}
@@ -413,7 +536,7 @@ class postgresql_query_builder {
 				foreach($endpoints as $endpoint){
 					$conn=self::connect_to_endpoint($endpoint, $dbms_cluster);
 					if(!self::execute_multi_query_string($conn, $multi_query_string, $results, $dbms_cluster)){
-						return self::retry_queue_after_hydration($queue, $queued_queries, $hydration_retry);
+						return self::retry_batch_after_hydration($queue, $queued_queries, $dbms_cluster, $hydration_retry);
 					}
 				}
 			}
@@ -423,13 +546,13 @@ class postgresql_query_builder {
 			$conn=self::connect_to_cluster($dbms_cluster);
 			if(!empty($prepared_statements)){
 				if(!self::execute_prepared_statements($conn,$prepared_statements,$results, $dbms_cluster)){
-					return self::retry_queue_after_hydration($queue, $queued_queries, $hydration_retry);
+					return self::retry_batch_after_hydration($queue, $queued_queries, $dbms_cluster, $hydration_retry);
 				}
 			}
 			else
 			{
 				if(!self::execute_multi_query_string($conn,$multi_query_string,$results, $dbms_cluster)){
-					return self::retry_queue_after_hydration($queue, $queued_queries, $hydration_retry);
+					return self::retry_batch_after_hydration($queue, $queued_queries, $dbms_cluster, $hydration_retry);
 				}
 			}
 		}
@@ -438,20 +561,34 @@ class postgresql_query_builder {
 	}
 
 	/**
-	 * Requeues a failed batch after attempting schema hydration once.
+	 * Retries a failed captured batch after attempting schema hydration once.
 	 *
 	 * @param string $queue Queue name that failed.
-	 * @param array<string, mixed> $queued_queries Original queued query payload.
+	 * @param list<array<string, mixed>> $queued_queries Original captured batch.
 	 * @param bool $hydration_retry Whether the caller is already in a hydration retry.
 	 * @return bool `true` when the retry completed successfully.
 	 */
+	private static function retry_batch_after_hydration(
+		string $queue,
+		array $queued_queries,
+		string $dbms_cluster,
+		bool $hydration_retry
+	): bool {
+		if($hydration_retry===true || sql::hydrate_missing_structure_from_definition()===false){
+			return false;
+		}
+		sql::clear_last_query_error();
+		return self::execute_multiquery_batch($queue, $queued_queries, $dbms_cluster, true);
+	}
+
+	/** Preserves the legacy grouped-queue hydration retry seam. */
 	private static function retry_queue_after_hydration(string $queue, array $queued_queries, bool $hydration_retry): bool {
 		if($hydration_retry===true || sql::hydrate_missing_structure_from_definition()===false){
 			return false;
 		}
 		self::$queued_queries[$queue]=$queued_queries;
 		sql::clear_last_query_error();
-		return self::execute_multiquery($queue, true) === true;
+		return self::execute_multiquery($queue, true)===true;
 	}
 	
 	/**

--- a/runtime/modules/sql/kernel/sql.main.php
+++ b/runtime/modules/sql/kernel/sql.main.php
@@ -13,6 +13,7 @@ dp_define_module_config('sql', 'DP_SQL_CFG', [
 	'default_cluster'=>'',
 	'default_database_location'=>'',
 	'safe_delete'=>true,
+	'data_environments'=>[],
 	'caching'=>[
 		'rolling_db_cache_size'=>256,
 		'default_policy'=>[
@@ -49,6 +50,60 @@ class sql {
 	private static array $table_definition_registry=[];
 	private static array $loaded_table_definition_files=[];
 	private static array $structure_hydration_retrying=[];
+
+	/**
+	 * Resolves an implicit SQL cluster through the active data environment.
+	 * Explicit query overrides are applied by the caller after this resolution.
+	 */
+	public static function resolve_cluster(?string $configured=null): string {
+		$configured=trim((string)($configured ?? (DP_SQL_CFG['default_cluster'] ?? '')));
+		if(class_exists('\Dataphyre\Database\DataEnvironment')){
+			$override=\Dataphyre\Database\DataEnvironment::clusterOverride();
+			if(is_string($override) && trim($override)!==''){
+				return trim($override);
+			}
+		}
+		return $configured;
+	}
+
+	/** Namespaces non-filesystem SQL cache keys for the active data environment. */
+	private static function environment_cache_key(string $key): string {
+		return class_exists('\Dataphyre\Database\DataEnvironment')
+			? \Dataphyre\Database\DataEnvironment::cacheKey($key)
+			: $key;
+	}
+
+	/** Namespaces filesystem SQL cache locations for the active data environment. */
+	private static function environment_cache_path(string $location): string {
+		return class_exists('\Dataphyre\Database\DataEnvironment')
+			? \Dataphyre\Database\DataEnvironment::cachePath($location)
+			: $location;
+	}
+
+	/**
+	 * Captures the execution-local SQL and cache context for deferred work.
+	 *
+	 * @return array{name:string,cluster:string,cache_namespace:?string,active:bool}
+	 */
+	private static function queued_environment_context(string $cluster): array {
+		$context=[
+			'name'=>'live',
+			'cluster'=>$cluster,
+			'cache_namespace'=>null,
+			'active'=>false,
+		];
+		if(!class_exists('\Dataphyre\Database\DataEnvironment')){
+			return $context;
+		}
+		$current=\Dataphyre\Database\DataEnvironment::current();
+		$context['name']=trim((string)($current['name'] ?? 'live')) ?: 'live';
+		$context['active']=\Dataphyre\Database\DataEnvironment::active();
+		$namespace=$current['cache_namespace'] ?? null;
+		$context['cache_namespace']=is_string($namespace) && trim($namespace)!==''
+			? trim($namespace)
+			: null;
+		return $context;
+	}
 
 	/**
 	 * Initializes the SQL kernel instance and registers bounded session-cache garbage collection on shutdown.
@@ -1328,12 +1383,14 @@ class sql {
 		if($cache_policy===null){
 			$cache_policy=self::get_table_cache_policy($location);
 		}
+		$cache_location=self::environment_cache_key($location);
+		$cache_path_location=self::environment_cache_path($location);
 		if($cache_policy!==false){
 			if($cache_policy['type']==="shared_cache"){
 				if(dp_module_present('cache')){
-					$table_cache_version=(int)cache::get('table_version_'.$location) ?? 0;
+					$table_cache_version=(int)cache::get('table_version_'.$cache_location) ?? 0;
 					tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T="Shared cache table version for $location: $table_cache_version)");
-					if(is_array($shared_cache_result=cache::get($key=$location.'_'.$hash))){
+					if(is_array($shared_cache_result=cache::get($key=$cache_location.'_'.$hash))){
 						if($shared_cache_result[0]===$table_cache_version){
 							tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T="Read from shared cache (".$key.")");
 							$_SESSION['queries_retrieved_from_cache']??=0;
@@ -1375,10 +1432,10 @@ class sql {
 				return null;
 			}
 			elseif($cache_policy['type']==="session"){
-				if(isset($_SESSION['db_cache'][$location][$hash])){
-					if($_SESSION['db_cache'][$location][$hash][1]>=strtotime("-".$cache_policy['max_lifespan'])){
+				if(isset($_SESSION['db_cache'][$cache_location][$hash])){
+					if($_SESSION['db_cache'][$cache_location][$hash][1]>=strtotime("-".$cache_policy['max_lifespan'])){
 						tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T="Read from session cache");
-						$cached_result=$_SESSION['db_cache'][$location][$hash][0];
+						$cached_result=$_SESSION['db_cache'][$cache_location][$hash][0];
 						$_SESSION['queries_retrieved_from_cache']??=0;
 						$_SESSION['queries_retrieved_from_cache']++;
 						self::emit_observer_event([
@@ -1391,7 +1448,7 @@ class sql {
 						]);
 						return $cached_result;
 					}
-					unset($_SESSION['db_cache'][$location][$hash]);
+					unset($_SESSION['db_cache'][$cache_location][$hash]);
 				}
 				tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T="Query not cached in session", $S="warning");
 				self::emit_observer_event([
@@ -1405,7 +1462,7 @@ class sql {
 				return null;
 			}
 			elseif($cache_policy['type']==="fs"){
-				$cache_file=__DIR__."/../../cache/sql/".$location."/".$hash;
+				$cache_file=__DIR__."/../../cache/sql/".$cache_path_location."/".$hash;
 				if(file_exists($cache_file)){
 					if(false!==$fs_cache=file_get_contents($cache_file)){
 						$fs_cache=json_decode($fs_cache, true);
@@ -1475,6 +1532,8 @@ class sql {
 		if($cache_policy===null){
 			$cache_policy=self::get_table_cache_policy($location);
 		}
+		$cache_location=self::environment_cache_key($location);
+		$cache_path_location=self::environment_cache_path($location);
 		if($cache_policy!==false){
 			if(empty($location)){
 				self::log_query_error('N/A', 'N/A', 'cache_query_result invalid location', [], new \Exception("Invalid cache location"));
@@ -1487,12 +1546,12 @@ class sql {
 			if($cache_policy['type']==='shared_cache'){
 				tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T="Caching in shared cache");
 				if($query_result===false)$query_result='false';
-				$table_cache_version=(int)cache::get('table_version_'.$location) ?? 0;
-				cache::set($location.'_'.$hash, array($table_cache_version, $query_result), strtotime($cache_policy['max_lifespan']));
+				$table_cache_version=(int)cache::get('table_version_'.$cache_location) ?? 0;
+				cache::set($cache_location.'_'.$hash, array($table_cache_version, $query_result), strtotime($cache_policy['max_lifespan']));
 			}
 			elseif($cache_policy['type']==='session'){
 				tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T="Caching in session");
-				$_SESSION['db_cache'][$location][$hash]=array($query_result, time());
+				$_SESSION['db_cache'][$cache_location][$hash]=array($query_result, time());
 				if($_SESSION['db_cache_count']>=DP_SQL_CFG['caching']['rolling_db_cache_size']){
 					array_shift($_SESSION['db_cache']);
 					tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T="Rolled session cache");
@@ -1504,7 +1563,7 @@ class sql {
 			}
 			elseif($cache_policy['type']==="fs"){
 				tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T="Caching in filesystem");
-				$cache_file=__DIR__."/../../cache/sql/".$location."/".$hash;
+				$cache_file=__DIR__."/../../cache/sql/".$cache_path_location."/".$hash;
 				core::file_put_contents_forced($cache_file, json_encode(array($query_result, time()), JSON_UNESCAPED_UNICODE));
 				$_SESSION['db_cache_count']++;
 			}
@@ -1515,7 +1574,9 @@ class sql {
 			}
 			foreach($caching as $cache_index){
 				if(is_bool($cache_index)===false){
-					$_SESSION['db_cache_invalidation_index'][$cache_index][]=[$cache_policy['type'],$location,$hash];
+					$cache_index=self::environment_cache_key((string)$cache_index);
+					$storage_location=$cache_policy['type']==='fs' ? $cache_path_location : $cache_location;
+					$_SESSION['db_cache_invalidation_index'][$cache_index][]=[$cache_policy['type'],$storage_location,$hash];
 				}
 			}
 			self::emit_observer_event([
@@ -1558,18 +1619,20 @@ class sql {
 		}
 		if($cache_policy!==false){
 			if(is_string($clear_cache_for)){
+				$cache_location=self::environment_cache_key($clear_cache_for);
+				$cache_path_location=self::environment_cache_path($clear_cache_for);
 				if($cache_policy['type']==="shared_cache"){
-					cache::increment('table_version_'.$clear_cache_for);
+					cache::increment('table_version_'.$cache_location);
 					tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T="Cleared shared cache for table $clear_cache_for");
 				}
 				elseif($cache_policy['type']==="session"){
-					$_SESSION['db_cache'][$clear_cache_for]??=[];
-					$_SESSION['db_cache_count']-=count($_SESSION['db_cache'][$clear_cache_for]);
-					unset($_SESSION['db_cache'][$clear_cache_for]);
+					$_SESSION['db_cache'][$cache_location]??=[];
+					$_SESSION['db_cache_count']-=count($_SESSION['db_cache'][$cache_location]);
+					unset($_SESSION['db_cache'][$cache_location]);
 					tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T="Cleared session cache for table $clear_cache_for");
 				}
 				elseif($cache_policy['type']==="fs"){
-					core::force_rmdir(__DIR__."/../../cache/sql/".$clear_cache_for."/");
+					core::force_rmdir(__DIR__."/../../cache/sql/".$cache_path_location."/");
 					tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T="Cleared filesystem cache for table $clear_cache_for");
 				}
 				else
@@ -1595,7 +1658,8 @@ class sql {
 		}
 		else
 		{
-			foreach($clear_cache_for as $clear_cache_index){
+			foreach($clear_cache_for as $logical_cache_index){
+				$clear_cache_index=self::environment_cache_key((string)$logical_cache_index);
 				$invalidated_count=0;
 				foreach($_SESSION['db_cache_invalidation_index'][$clear_cache_index] ?? [] as $invalidation_cache){
 					if($invalidation_cache[0]==='shared_cache'){
@@ -1697,7 +1761,7 @@ class sql {
 			'postgresql'=>'BEGIN',
 			'sqlite'=>'BEGIN TRANSACTION',
 			'dbms_cluster_override'=>$cluster
-		]);
+		], null, false, false, false);
 	}
 
 	/**
@@ -1714,7 +1778,7 @@ class sql {
 			'postgresql'=>'COMMIT',
 			'sqlite'=>'COMMIT',
 			'dbms_cluster_override'=>$cluster
-		]);
+		], null, false, false, false);
 	}
 
 	/**
@@ -1731,7 +1795,7 @@ class sql {
 			'postgresql'=>'ROLLBACK',
 			'sqlite'=>'ROLLBACK',
 			'dbms_cluster_override'=>$cluster
-		]);
+		], null, false, false, false);
 	}
 	
 	/**
@@ -1775,7 +1839,7 @@ class sql {
 		if($clear_cache!==false){
 			if(is_array($clear_cache)===false)$clear_cache=[$clear_cache];
 		}
-		$dbms_cluster=DP_SQL_CFG['tables'][$location]['cluster']??DP_SQL_CFG['default_cluster'];
+		$dbms_cluster=self::resolve_cluster(DP_SQL_CFG['tables'][$location]['cluster']??DP_SQL_CFG['default_cluster']);
 		if(isset($query['dbms_cluster_override']))$dbms_cluster=$query['dbms_cluster_override'];
 		$dbms=DP_SQL_CFG['datacenters'][DP_CORE_CFG['datacenter']]['dbms_clusters'][$dbms_cluster]['dbms'];
 		if(is_array($query)){
@@ -1797,7 +1861,7 @@ class sql {
 			return false;
 		}
 		if($callback){
-			$query_queue=function($vars)use($location, $query, $associative, $caching, $multipoint, $clear_cache, $callback, $hash){
+			$query_queue=function($vars)use($location, $query, $associative, $caching, $multipoint, $clear_cache, $callback, $hash, $dbms_cluster){
 				return [
 					'location'=>$location, 
 					'query'=>$query,
@@ -1807,7 +1871,9 @@ class sql {
 					'multipoint'=>$multipoint,
 					'clear_cache'=>$clear_cache,
 					'callback'=>$callback,
-					'hash'=>$hash
+					'hash'=>$hash,
+					'dbms_cluster'=>$dbms_cluster,
+					'data_environment'=>self::queued_environment_context($dbms_cluster)
 				];
 			};
 		}
@@ -1982,7 +2048,7 @@ class sql {
 				}
 			}
 		}
-		$dbms_cluster=DP_SQL_CFG['tables'][$location]['cluster']??DP_SQL_CFG['default_cluster'];
+		$dbms_cluster=self::resolve_cluster(DP_SQL_CFG['tables'][$location]['cluster']??DP_SQL_CFG['default_cluster']);
 		$dbms=DP_SQL_CFG['datacenters'][DP_CORE_CFG['datacenter']]['dbms_clusters'][$dbms_cluster]['dbms'];
 		if(is_array($select)){
 			if(!isset($select[$dbms])){
@@ -2001,7 +2067,7 @@ class sql {
 		if(is_array($vars) && isset($vars[$dbms]))$vars=$vars[$dbms];
 		if($associative!==true && stripos($params, 'limit')===false && !is_null($params))$params.=' LIMIT 1'; 
 		if($callback){
-			$query_queue=function($vars)use($select, $location, $params, $associative, $caching, $callback, $hash){
+			$query_queue=function($vars)use($select, $location, $params, $associative, $caching, $callback, $hash, $dbms_cluster){
 				return [
 					'select'=>$select, 
 					'location'=>$location,
@@ -2010,7 +2076,9 @@ class sql {
 					'associative'=>$associative, 
 					'caching'=>$caching,
 					'callback'=>$callback,
-					'hash'=>$hash
+					'hash'=>$hash,
+					'dbms_cluster'=>$dbms_cluster,
+					'data_environment'=>self::queued_environment_context($dbms_cluster)
 				];
 			};
 		}
@@ -2162,7 +2230,7 @@ class sql {
 				}
 			}
 		}
-		$dbms_cluster=DP_SQL_CFG['tables'][$location]['cluster']??DP_SQL_CFG['default_cluster'];
+		$dbms_cluster=self::resolve_cluster(DP_SQL_CFG['tables'][$location]['cluster']??DP_SQL_CFG['default_cluster']);
 		$dbms=DP_SQL_CFG['datacenters'][DP_CORE_CFG['datacenter']]['dbms_clusters'][$dbms_cluster]['dbms'];
 		if($query_dbms && $dbms!==$query_dbms){
 			self::log_query_error($dbms, 'N/A', 'count dbms compatibility check for '.$location, [], new \Exception("Query has explicit DBMS compatibility flag $query_dbms that is not compatible with DBMS ($dbms) for location $location."));
@@ -2177,14 +2245,16 @@ class sql {
 		}
 		if(is_array($vars) && isset($vars[$dbms]))$vars=$vars[$dbms];
 		if($callback){
-			$query_queue=function($vars)use($location, $params, $caching, $callback, $hash){
+			$query_queue=function($vars)use($location, $params, $caching, $callback, $hash, $dbms_cluster){
 				return [
 					'location'=>$location, 
 					'params'=>$params,
 					'vars'=>$vars, 
 					'caching'=>$caching, 
 					'callback'=>$callback,
-					'hash'=>$hash
+					'hash'=>$hash,
+					'dbms_cluster'=>$dbms_cluster,
+					'data_environment'=>self::queued_environment_context($dbms_cluster)
 				];
 			};
 		}
@@ -2316,7 +2386,7 @@ class sql {
 		}
 		if($clear_cache===null)$clear_cache=false;
 		$location=self::table($location, $query_dbms);
-		$dbms_cluster=DP_SQL_CFG['tables'][$location]['cluster']??DP_SQL_CFG['default_cluster'];
+		$dbms_cluster=self::resolve_cluster(DP_SQL_CFG['tables'][$location]['cluster']??DP_SQL_CFG['default_cluster']);
 		$dbms=DP_SQL_CFG['datacenters'][DP_CORE_CFG['datacenter']]['dbms_clusters'][$dbms_cluster]['dbms'];
 		if(is_array($vars)){
 			if(isset($vars[$dbms])){
@@ -2335,7 +2405,7 @@ class sql {
 		}
 		$returning='*';
 		if($callback){
-			$query_queue=function($vars)use($location, $fields, $clear_cache, $callback, $returning){
+			$query_queue=function($vars)use($location, $fields, $clear_cache, $callback, $returning, $dbms_cluster){
 				return [
 					'location'=>$location, 
 					'ignore'=>'IGNORE',
@@ -2345,7 +2415,9 @@ class sql {
 					'callback'=>$callback,
 					'multipoint'=>true,
 					'associative'=>false,
-					'returning'=>$returning
+					'returning'=>$returning,
+					'dbms_cluster'=>$dbms_cluster,
+					'data_environment'=>self::queued_environment_context($dbms_cluster)
 				];
 			};
 		}
@@ -2472,7 +2544,7 @@ class sql {
 		$vars??=[];
 		if($clear_cache===null)$clear_cache=false;
 		$location=self::table($location, $query_dbms);
-		$dbms_cluster=DP_SQL_CFG['tables'][$location]['cluster']??DP_SQL_CFG['default_cluster'];
+		$dbms_cluster=self::resolve_cluster(DP_SQL_CFG['tables'][$location]['cluster']??DP_SQL_CFG['default_cluster']);
 		$dbms=DP_SQL_CFG['datacenters'][DP_CORE_CFG['datacenter']]['dbms_clusters'][$dbms_cluster]['dbms'];
 		if(is_array($fields) && isset($fields[$dbms]))$fields=$fields[$dbms];
 		if(is_array($vars) && isset($vars[$dbms]))$vars=$vars[$dbms];
@@ -2495,7 +2567,7 @@ class sql {
 			return $callback ? null : 0;
 		}
 		if($callback){
-			$query_queue=function($vars)use($location, $fields, $params, $callback, $clear_cache){
+			$query_queue=function($vars)use($location, $fields, $params, $callback, $clear_cache, $dbms_cluster){
 				return [
 					'location'=>$location,
 					'fields'=>$fields, 
@@ -2503,7 +2575,9 @@ class sql {
 					'vars'=>$vars,
 					'clear_cache'=>$clear_cache,
 					'callback'=>$callback,
-					'multipoint'=>true
+					'multipoint'=>true,
+					'dbms_cluster'=>$dbms_cluster,
+					'data_environment'=>self::queued_environment_context($dbms_cluster)
 				];
 			};
 		}
@@ -2646,7 +2720,7 @@ class sql {
 		$original_clear_cache=$clear_cache;
 		$trace_started_at=microtime(true);
 		$location=self::table($location, $query_dbms);
-		$dbms_cluster=DP_SQL_CFG['tables'][$location]['cluster']??DP_SQL_CFG['default_cluster'];
+		$dbms_cluster=self::resolve_cluster(DP_SQL_CFG['tables'][$location]['cluster']??DP_SQL_CFG['default_cluster']);
 		$dbms=DP_SQL_CFG['datacenters'][DP_CORE_CFG['datacenter']]['dbms_clusters'][$dbms_cluster]['dbms'];
 		if(is_array($params)){
 			if(!isset($params[$dbms])){
@@ -2668,14 +2742,16 @@ class sql {
 			return $callback ? null : 0;
 		}
 		if($callback){
-			$query_queue=function($vars)use($location, $params, $clear_cache, $callback){
+			$query_queue=function($vars)use($location, $params, $clear_cache, $callback, $dbms_cluster){
 				return [
 					'location'=>$location, 
 					'params'=>$params,
 					'vars'=>$vars,
 					'clear_cache'=>$clear_cache,
 					'callback'=>$callback,
-					'multipoint'=>true
+					'multipoint'=>true,
+					'dbms_cluster'=>$dbms_cluster,
+					'data_environment'=>self::queued_environment_context($dbms_cluster)
 				];
 			};
 		}
@@ -2808,7 +2884,7 @@ class sql {
 		$update_vars ??=[];
 		if($clear_cache===null) $clear_cache=false;
 		$location=self::table($location, $query_dbms);
-		$dbms_cluster=DP_SQL_CFG['tables'][$location]['cluster'] ?? DP_SQL_CFG['default_cluster'];
+		$dbms_cluster=self::resolve_cluster(DP_SQL_CFG['tables'][$location]['cluster'] ?? DP_SQL_CFG['default_cluster']);
 		$dbms=DP_SQL_CFG['datacenters'][DP_CORE_CFG['datacenter']]['dbms_clusters'][$dbms_cluster]['dbms'];
 		if(is_array($fields[$dbms] ?? null)){
 			if($dbms==='postgresql'){
@@ -2860,7 +2936,7 @@ class sql {
 					$updates=implode(",", array_map(fn($k)=>"`$k`=VALUES(`$k`)", $columns));
 					$sql="INSERT INTO `$location` (`".implode("`,`", $columns)."`) VALUES ($placeholders) ON DUPLICATE KEY UPDATE $updates";
 					if($callback){
-						$query_queue=function($vars)use($location, $sql, $clear_cache, $callback){
+						$query_queue=function($vars)use($location, $sql, $clear_cache, $callback, $dbms_cluster){
 							return [
 								'location'=>$location,
 								'query'=>$sql,
@@ -2869,7 +2945,9 @@ class sql {
 								'caching'=>false,
 								'multipoint'=>false,
 								'clear_cache'=>$clear_cache,
-								'callback'=>$callback
+								'callback'=>$callback,
+								'dbms_cluster'=>$dbms_cluster,
+								'data_environment'=>self::queued_environment_context($dbms_cluster)
 							];
 						};
 						mysql_query_builder::$queued_queries[$queue]['raw'][]=$query_queue($vars);
@@ -2897,7 +2975,7 @@ class sql {
 					$updates=implode(',', array_map(fn($k)=>"\"$k\"=EXCLUDED.\"$k\"", array_keys($fields)));
 					$sql="INSERT INTO $quoted_location (\"$quoted_columns\") VALUES ($placeholders) ON CONFLICT $conflict_target DO UPDATE SET $updates";
 					if($callback){
-						$query_queue=function($vars)use($location, $sql, $clear_cache, $callback){
+						$query_queue=function($vars)use($location, $sql, $clear_cache, $callback, $dbms_cluster){
 							return [
 								'location'=>$location,
 								'query'=>$sql,
@@ -2906,7 +2984,9 @@ class sql {
 								'caching'=>false,
 								'multipoint'=>false,
 								'clear_cache'=>$clear_cache,
-								'callback'=>$callback
+								'callback'=>$callback,
+								'dbms_cluster'=>$dbms_cluster,
+								'data_environment'=>self::queued_environment_context($dbms_cluster)
 							];
 						};
 						postgresql_query_builder::$queued_queries[$queue]['raw'][]=$query_queue($vars);
@@ -2933,7 +3013,7 @@ class sql {
 					$updates=implode(",", array_map(fn($k)=>"\"$k\"=excluded.\"$k\"", $columns));
 					$sql="INSERT INTO $quoted_location (\"".implode('","', $columns)."\") VALUES ($placeholders) ON CONFLICT DO UPDATE SET $updates";
 					if($callback){
-						$query_queue=function($vars)use($location, $sql, $clear_cache, $callback){
+						$query_queue=function($vars)use($location, $sql, $clear_cache, $callback, $dbms_cluster){
 							return [
 								'location'=>$location,
 								'query'=>$sql,
@@ -2942,7 +3022,9 @@ class sql {
 								'caching'=>false,
 								'multipoint'=>false,
 								'clear_cache'=>$clear_cache,
-								'callback'=>$callback
+								'callback'=>$callback,
+								'dbms_cluster'=>$dbms_cluster,
+								'data_environment'=>self::queued_environment_context($dbms_cluster)
 							];
 						};
 						sqlite_query_builder::$queued_queries[$queue]['raw'][]=$query_queue($vars);

--- a/runtime/modules/sql/kernel/sqlite_query.php
+++ b/runtime/modules/sql/kernel/sqlite_query.php
@@ -292,6 +292,83 @@ class sqlite_query_builder {
 		}
 		return $query_list;
 	}
+
+	/**
+	 * Resolves the immutable data environment captured when a query was queued.
+	 *
+	 * Explicit non-empty cluster metadata is already resolved by the SQL kernel
+	 * and must not be passed through the ambient cluster resolver again. Legacy
+	 * payloads without a snapshot retain the environment active when drained.
+	 *
+	 * @param array<string, mixed> $query_info Queued query metadata.
+	 * @return array{name:string,cluster:string,cache_namespace:?string,captured:bool,active:bool}
+	 */
+	private static function queued_environment(array $query_info): array {
+		$current=[
+			'name'=>'live',
+			'cluster'=>null,
+			'cache_namespace'=>null,
+		];
+		if(class_exists('\\Dataphyre\\Database\\DataEnvironment')){
+			$current=\Dataphyre\Database\DataEnvironment::current();
+		}
+		$captured=is_array($query_info['data_environment'] ?? null);
+		$snapshot=$captured
+			? $query_info['data_environment']
+			: [];
+		$name=strtolower(trim((string)($snapshot['name'] ?? $current['name'] ?? 'live')));
+		if($name==='' || preg_match('/^[a-z0-9][a-z0-9._-]*$/D', $name)!==1){
+			$name='live';
+		}
+		$cluster='';
+		foreach([
+			$query_info['dbms_cluster'] ?? null,
+			$snapshot['cluster'] ?? null,
+			$current['cluster'] ?? null,
+			DP_SQL_CFG['tables']['raw']['cluster'] ?? DP_SQL_CFG['default_cluster'] ?? '',
+		] as $candidate){
+			if(!is_string($candidate) || trim($candidate)===''){
+				continue;
+			}
+			$cluster=trim($candidate);
+			break;
+		}
+		$namespace=array_key_exists('cache_namespace', $snapshot)
+			? $snapshot['cache_namespace']
+			: ($current['cache_namespace'] ?? null);
+		$namespace=is_string($namespace) && trim($namespace)!=='' ? trim($namespace) : null;
+		$active=$captured
+			? (bool)($snapshot['active'] ?? true)
+			: (class_exists('\\Dataphyre\\Database\\DataEnvironment') && \Dataphyre\Database\DataEnvironment::active());
+		return [
+			'name'=>$name,
+			'cluster'=>$cluster,
+			'cache_namespace'=>$namespace,
+			'captured'=>$captured,
+			'active'=>$active,
+		];
+	}
+
+	/** Runs execution and result side effects inside a captured data environment. */
+	private static function run_in_queued_environment(array $environment, callable $callback): mixed {
+		if(
+			($environment['captured'] ?? false)!==true
+			|| !class_exists('\\Dataphyre\\Database\\DataEnvironment')
+		){
+			return $callback();
+		}
+		if(($environment['active'] ?? true)!==true && !\Dataphyre\Database\DataEnvironment::active()){
+			return $callback();
+		}
+		return \Dataphyre\Database\DataEnvironment::run(
+			(string)$environment['name'],
+			static fn(): mixed=>$callback(),
+			[
+				'cluster'=>(string)$environment['cluster'],
+				'cache_namespace'=>$environment['cache_namespace'],
+			]
+		);
+	}
 	
 	/**
 	 * Flushes a named SQLite queue through the configured database file.
@@ -312,13 +389,56 @@ class sqlite_query_builder {
 		if(!isset(self::$queued_queries[$queue]))return null;
 		$queued_queries=self::$queued_queries[$queue];
 		unset(self::$queued_queries[$queue]);
+		$batches=[];
+		foreach(self::queued_query_list($queued_queries) as $query_info){
+			$environment=self::queued_environment($query_info);
+			$batch_index=array_key_last($batches);
+			if($batch_index===null || $batches[$batch_index]['environment']!==$environment){
+				$batches[]=[
+					'environment'=>$environment,
+					'queries'=>[],
+				];
+				$batch_index=array_key_last($batches);
+			}
+			$batches[$batch_index]['queries'][]=$query_info;
+		}
+		$success=true;
+		foreach($batches as $batch){
+			$result=self::run_in_queued_environment(
+				$batch['environment'],
+				static fn(): bool=>self::execute_multiquery_batch(
+					$queue,
+					$batch['queries'],
+					(string)$batch['environment']['cluster'],
+					$hydration_retry
+				)
+			);
+			if($result!==true){
+				$success=false;
+			}
+		}
+		return $success;
+	}
+
+	/**
+	 * Executes one cluster-homogeneous SQLite queue batch.
+	 *
+	 * @param list<array<string,mixed>> $queued_queries Queries in the best order
+	 *        recoverable from the legacy type-grouped queue representation.
+	 */
+	private static function execute_multiquery_batch(
+		string $queue,
+		array $queued_queries,
+		string $dbms_cluster,
+		bool $hydration_retry
+	): bool {
 		$multipoint=false;
 		$queries=[];
 		$multi_query_string="";
 		$index=0;
 		$prepared_statements=[];
-		foreach($queued_queries as $query_type=>$query_info_array){
-			foreach($query_info_array as $query_info){
+		foreach($queued_queries as $query_info){
+				$query_type=trim((string)($query_info['type'] ?? 'raw')) ?: 'raw';
 				if($query_type==='select'){
 					$query_info['query']="SELECT {$query_info['select']} FROM {$query_info['location']} {$query_info['params']}";
 				}
@@ -347,21 +467,19 @@ class sqlite_query_builder {
 				$query_info['type']=$query_type;
 				$queries[$index]=$query_info;
 				$index++;
-			}
 		}
 		$results=[];
-		$dbms_cluster=DP_SQL_CFG['tables']['raw']['cluster'] ?? DP_SQL_CFG['default_cluster'];
 		$endpoint=DP_SQL_CFG['datacenters'][DP_CORE_CFG['datacenter']]['dbms_clusters'][$dbms_cluster]['endpoints'][0];
 		$conn=self::connect_to_endpoint($endpoint, $dbms_cluster);
 		if(!empty($prepared_statements)){
 			if(!self::execute_prepared_statements($conn, $prepared_statements, $results, $dbms_cluster)){
-				return self::retry_queue_after_hydration($queue, $queued_queries, $hydration_retry);
+				return self::retry_batch_after_hydration($queue, $queued_queries, $dbms_cluster, $hydration_retry);
 			}
 		}
 		else
 		{
 			if(!self::execute_multi_query_string($conn, $multi_query_string, $results, $dbms_cluster)){
-				return self::retry_queue_after_hydration($queue, $queued_queries, $hydration_retry);
+				return self::retry_batch_after_hydration($queue, $queued_queries, $dbms_cluster, $hydration_retry);
 			}
 		}
 		self::process_results($results, $queries);
@@ -369,7 +487,7 @@ class sqlite_query_builder {
 	}
 
 	/**
-	 * Restores a failed queue and retries it after definition-driven hydration.
+	 * Retries a failed captured batch after definition-driven hydration.
 	 *
 	 * This is the SQLite queue recovery path for missing tables or columns that
 	 * Dataphyre can create from table definitions. The method clears the last
@@ -377,17 +495,31 @@ class sqlite_query_builder {
 	 * rather than the initial structural failure.
 	 *
 	 * @param string $queue Queue name that failed execution.
-	 * @param array<string, array<int, array<string, mixed>>> $queued_queries Original grouped queue payload.
+	 * @param list<array<string, mixed>> $queued_queries Original captured batch.
 	 * @param bool $hydration_retry Whether the current call is already the retry attempt.
 	 * @return bool `true` only when hydration runs and the restored queue succeeds on its guarded retry.
 	 */
+	private static function retry_batch_after_hydration(
+		string $queue,
+		array $queued_queries,
+		string $dbms_cluster,
+		bool $hydration_retry
+	): bool {
+		if($hydration_retry===true || sql::hydrate_missing_structure_from_definition()===false){
+			return false;
+		}
+		sql::clear_last_query_error();
+		return self::execute_multiquery_batch($queue, $queued_queries, $dbms_cluster, true);
+	}
+
+	/** Preserves the legacy grouped-queue hydration retry seam. */
 	private static function retry_queue_after_hydration(string $queue, array $queued_queries, bool $hydration_retry): bool {
 		if($hydration_retry===true || sql::hydrate_missing_structure_from_definition()===false){
 			return false;
 		}
 		self::$queued_queries[$queue]=$queued_queries;
 		sql::clear_last_query_error();
-		return self::execute_multiquery($queue, true) === true;
+		return self::execute_multiquery($queue, true)===true;
 	}
 	
 	/**

--- a/runtime/modules/sql/unit_tests/dynamic/dataphyre.sql_postgresql_environment_compatibility.test.php
+++ b/runtime/modules/sql/unit_tests/dynamic/dataphyre.sql_postgresql_environment_compatibility.test.php
@@ -1,0 +1,364 @@
+<?php
+/*************************************************************************
+ * Dataphyre
+ *
+ * Copyright (c) 2026 Shopiro Ltd.
+ * SPDX-License-Identifier: MIT
+ */
+declare(strict_types=1);
+
+use Dataphyre\Database\ConnectionContext;
+use Dataphyre\Database\DataEnvironment;
+use Dataphyre\Database\DB;
+use Dataphyre\Database\TableDefinition;
+use Dataphyre\Test\Context;
+use function Dataphyre\Test\define_test_symbols;
+use function Dataphyre\Test\framework;
+use function Dataphyre\Test\test;
+
+$compatibilityHost=trim((string)(getenv('DATAPHYRE_SQL_COMPAT_HOST') ?: getenv('SERVE_DB_HOST') ?: 'postgres'));
+$compatibilityPort=(int)(getenv('DATAPHYRE_SQL_COMPAT_PORT') ?: getenv('SERVE_DB_PORT') ?: 5432);
+$compatibilityUser=trim((string)(getenv('DATAPHYRE_SQL_COMPAT_USERNAME') ?: getenv('SERVE_DB_USERNAME') ?: 'application_user'));
+$compatibilityPassword=(string)(getenv('DATAPHYRE_SQL_COMPAT_PASSWORD') ?: getenv('SERVE_DB_PASSWORD') ?: '');
+$compatibilityLiveDatabase=trim((string)(getenv('DATAPHYRE_SQL_COMPAT_LIVE_DATABASE') ?: 'dataphyre_sql_compat_missing_live'));
+$compatibilitySandboxDatabase=trim((string)(getenv('DATAPHYRE_SQL_COMPAT_SANDBOX_DATABASE') ?: 'dataphyre_sql_compat_missing_sandbox'));
+
+if(!class_exists('dataphyre\core', false)){
+	define_test_symbols(<<<'PHP'
+namespace dataphyre;
+function ellipsis(string $string, int $length, string $direction='right'): string { return $string; }
+final class core {
+	public static function dialback(string $name, mixed ...$arguments): mixed { return null; }
+	public static function unavailable(mixed ...$arguments): never { throw new \RuntimeException('Dataphyre SQL reported an unavailable dependency.'); }
+	public static function get_password(string $endpoint): string { return ''; }
+	public static function load_framework_module(string $module): bool { return true; }
+	public static function file_put_contents_forced(string $file, string $contents): int|false {
+		$directory=dirname($file);
+		if(!is_dir($directory)){ mkdir($directory, 0777, true); }
+		return file_put_contents($file, $contents);
+	}
+	public static function force_rmdir(string $directory): bool { return true; }
+}
+PHP);
+}
+
+framework(['sql'], [
+	'constants'=>[
+		'DP_CORE_CFG'=>[
+			'datacenter'=>'compatibility',
+		],
+		'DP_SQL_CFG'=>[
+			'default_cluster'=>'compatibility_live',
+			'default_database_location'=>'',
+			'safe_delete'=>true,
+			'data_environments'=>[
+				'sandbox'=>[
+					'cluster'=>'compatibility_sandbox',
+					'cache_namespace'=>'compatibility-sandbox',
+				],
+			],
+			'caching'=>[
+				'rolling_db_cache_size'=>256,
+				'default_policy'=>[
+					'type'=>'session',
+					'max_lifespan'=>'30 minute',
+					'hash_type'=>'md5',
+				],
+			],
+			'datacenters'=>[
+				'compatibility'=>[
+					'dbms_clusters'=>[
+						'compatibility_live'=>[
+							'dbms'=>'postgresql',
+							'endpoints'=>[$compatibilityHost],
+							'dbms_username'=>$compatibilityUser,
+							'database_name'=>$compatibilityLiveDatabase,
+							'dbms_port'=>$compatibilityPort,
+							'password'=>$compatibilityPassword,
+						],
+						'compatibility_sandbox'=>[
+							'dbms'=>'postgresql',
+							'endpoints'=>[$compatibilityHost],
+							'dbms_username'=>$compatibilityUser,
+							'database_name'=>$compatibilitySandboxDatabase,
+							'dbms_port'=>$compatibilityPort,
+							'password'=>$compatibilityPassword,
+						],
+					],
+				],
+			],
+			'tables'=>[
+				'raw'=>[
+					'cluster'=>'compatibility_live',
+					'caching'=>[
+						'type'=>'session',
+						'max_lifespan'=>'30 minute',
+						'hash_type'=>'md5',
+					],
+				],
+			],
+		],
+	],
+	'functions'=>[
+		'dataphyre\tracelog',
+		'dataphyre\dp_define_module_config',
+		'dataphyre\log_error',
+		'dataphyre\dp_module_present',
+		'dataphyre_shutdown_log',
+	],
+	'files'=>[
+		'sql/kernel/sql.main.php',
+	],
+]);
+
+function dp_sql_postgresql_environment_enabled(Context $t): void {
+	if((string)(getenv('DATAPHYRE_SQL_POSTGRES_COMPATIBILITY') ?: '')!=='1'){
+		$t->skip('Set DATAPHYRE_SQL_POSTGRES_COMPATIBILITY=1 and provide two disposable PostgreSQL databases.');
+	}
+	if(!extension_loaded('pgsql')){
+		$t->skip('The PostgreSQL extension is unavailable.');
+	}
+}
+
+function dp_sql_postgresql_environment_query(
+	string $query,
+	?array $variables=null,
+	bool $associative=false
+): mixed {
+	return \dataphyre\sql::query(
+		['postgresql'=>$query],
+		$variables,
+		$associative,
+		false,
+		false,
+		false
+	);
+}
+
+/** @return list<int> */
+function dp_sql_postgresql_environment_marker_ids(string $table): array {
+	$rows=dp_sql_postgresql_environment_query(
+		'SELECT id FROM '.$table.' ORDER BY id',
+		null,
+		true
+	);
+	return array_map(
+		static fn(array $row): int=>(int)($row['id'] ?? 0),
+		is_array($rows) ? $rows : []
+	);
+}
+
+function dp_sql_postgresql_environment_reset_markers(string $table): void {
+	dp_sql_postgresql_environment_query(
+		'CREATE TABLE IF NOT EXISTS '.$table.' (id INTEGER PRIMARY KEY, label TEXT NOT NULL)'
+	);
+	dp_sql_postgresql_environment_query('TRUNCATE TABLE '.$table);
+}
+
+test('PostgreSQL ambient routing keeps explicit clusters authoritative', static function(Context $t) use (
+	$compatibilityLiveDatabase,
+	$compatibilitySandboxDatabase
+): void {
+	dp_sql_postgresql_environment_enabled($t);
+	$t->globalMap('_SESSION')->clear()->put('db_cache_count', 0);
+	DataEnvironment::run('live', static function(): void {
+		dp_sql_postgresql_environment_reset_markers('dataphyre_sql_environment_routing_markers');
+	});
+	DataEnvironment::run('sandbox', static function(): void {
+		dp_sql_postgresql_environment_reset_markers('dataphyre_sql_environment_routing_markers');
+	});
+
+	DataEnvironment::run('sandbox', static function() use (
+		$t,
+		$compatibilityLiveDatabase,
+		$compatibilitySandboxDatabase
+	): void {
+		$t->same('compatibility_sandbox', DB::connection()->cluster());
+		$t->same('compatibility_sandbox', DB::connection(' ')->cluster());
+		$t->same('compatibility_live', DB::connection('compatibility_live')->cluster());
+		$t->same(
+			$compatibilitySandboxDatabase,
+			DB::connection()->row('SELECT current_database()')['current_database'] ?? null
+		);
+		$t->same(
+			$compatibilityLiveDatabase,
+			DB::connection('compatibility_live')->row('SELECT current_database()')['current_database'] ?? null
+		);
+
+		$live=DB::connection('compatibility_live');
+		$live->transaction(static function(ConnectionContext $connection) use ($t, $compatibilityLiveDatabase): void {
+			$t->same(
+				$compatibilityLiveDatabase,
+				$connection->row('SELECT current_database()')['current_database'] ?? null
+			);
+			$connection->query(
+				'INSERT INTO dataphyre_sql_environment_routing_markers (id, label) VALUES (?, ?)',
+				[7, 'explicit-live-inside-sandbox']
+			);
+		});
+	});
+
+	DataEnvironment::run('live', static function() use ($t): void {
+		$t->same([7], dp_sql_postgresql_environment_marker_ids('dataphyre_sql_environment_routing_markers'));
+	});
+	DataEnvironment::run('sandbox', static function() use ($t): void {
+		$t->same([], dp_sql_postgresql_environment_marker_ids('dataphyre_sql_environment_routing_markers'));
+	});
+	$t->same('live', DataEnvironment::name());
+})->tag('sql', 'postgresql', 'transaction', 'data-environment', 'compatibility')->maxMillis(15000);
+
+test('PostgreSQL deferred queues retain registration-time cluster and cache namespace', static function(Context $t): void {
+	dp_sql_postgresql_environment_enabled($t);
+	$session=$t->globalMap('_SESSION')->clear()->put('db_cache_count', 0);
+	DataEnvironment::run('live', static function(): void {
+		dp_sql_postgresql_environment_reset_markers('dataphyre_sql_environment_queue_markers');
+	});
+	DataEnvironment::run('sandbox', static function(): void {
+		dp_sql_postgresql_environment_reset_markers('dataphyre_sql_environment_queue_markers');
+	});
+
+	$writeCallbacks=[];
+	foreach(['live'=>11, 'sandbox'=>22] as $environment=>$id){
+		$registerWrite=static function() use (&$writeCallbacks, $environment, $id): void {
+			\dataphyre\sql::query(
+				['postgresql'=>'INSERT INTO dataphyre_sql_environment_queue_markers (id, label) VALUES (?, ?)'],
+				[$id, $environment.'-queued'],
+				false,
+				false,
+				false,
+				false,
+				'environment-compatibility-write',
+				static function(mixed $result) use (&$writeCallbacks): void {
+					$writeCallbacks[]=[
+						DataEnvironment::name(),
+						DataEnvironment::cacheKey('raw'),
+						DataEnvironment::active(),
+						$result!==false,
+					];
+				}
+			);
+		};
+		if($environment==='live'){
+			$registerWrite();
+		}else{
+			DataEnvironment::run($environment, $registerWrite);
+		}
+	}
+	$writeExecuted=\dataphyre\sql::execute_queue('environment-compatibility-write');
+	$t->isTrue(
+		$writeExecuted,
+		'Queued writes failed: '.json_encode(\dataphyre\sql::last_query_error(), JSON_UNESCAPED_SLASHES)
+	);
+	$t->same([
+		['live', 'raw', false, true],
+		['sandbox', 'compatibility-sandbox::raw', true, true],
+	], $writeCallbacks);
+	DataEnvironment::run('live', static function() use ($t): void {
+		$t->same([11], dp_sql_postgresql_environment_marker_ids('dataphyre_sql_environment_queue_markers'));
+	});
+	DataEnvironment::run('sandbox', static function() use ($t): void {
+		$t->same([22], dp_sql_postgresql_environment_marker_ids('dataphyre_sql_environment_queue_markers'));
+	});
+
+	$readCallbacks=[];
+	foreach(['live', 'sandbox'] as $environment){
+		$registerRead=static function() use (&$readCallbacks): void {
+			\dataphyre\sql::query(
+				['postgresql'=>'SELECT id FROM dataphyre_sql_environment_queue_markers ORDER BY id'],
+				null,
+				true,
+				false,
+				[true],
+				false,
+				'environment-compatibility-read',
+				static function(mixed $result) use (&$readCallbacks): void {
+					$readCallbacks[DataEnvironment::name()]=[
+						'ids'=>array_map(static fn(array $row): int=>(int)$row['id'], is_array($result) ? $result : []),
+						'cache_key'=>DataEnvironment::cacheKey('raw'),
+						'active'=>DataEnvironment::active(),
+					];
+				}
+			);
+		};
+		if($environment==='live'){
+			$registerRead();
+		}else{
+			DataEnvironment::run($environment, $registerRead);
+		}
+	}
+	$readExecuted=\dataphyre\sql::execute_queue('environment-compatibility-read');
+	$t->isTrue(
+		$readExecuted,
+		'Queued reads failed: '.json_encode(\dataphyre\sql::last_query_error(), JSON_UNESCAPED_SLASHES)
+	);
+	$t->same(['ids'=>[11], 'cache_key'=>'raw', 'active'=>false], $readCallbacks['live'] ?? null);
+	$t->same(
+		['ids'=>[22], 'cache_key'=>'compatibility-sandbox::raw', 'active'=>true],
+		$readCallbacks['sandbox'] ?? null
+	);
+	$t->isTrue(is_array($session->getPath(['db_cache', 'raw'])));
+	$t->isTrue(is_array($session->getPath(['db_cache', 'compatibility-sandbox::raw'])));
+
+	$crossEnvironmentDrain=[];
+	\dataphyre\sql::query(
+		['postgresql'=>'SELECT id FROM dataphyre_sql_environment_queue_markers ORDER BY id'],
+		null,
+		true,
+		false,
+		false,
+		false,
+		'environment-compatibility-cross-drain',
+		static function(mixed $result) use (&$crossEnvironmentDrain): void {
+			$crossEnvironmentDrain=[
+				'name'=>DataEnvironment::name(),
+				'cache_key'=>DataEnvironment::cacheKey('raw'),
+				'active'=>DataEnvironment::active(),
+				'ids'=>array_map(static fn(array $row): int=>(int)$row['id'], is_array($result) ? $result : []),
+			];
+		}
+	);
+	DataEnvironment::run('sandbox', static function() use ($t): void {
+		$t->isTrue(\dataphyre\sql::execute_queue('environment-compatibility-cross-drain'));
+		$t->same('sandbox', DataEnvironment::name());
+	});
+	$t->same(
+		['name'=>'live', 'cache_key'=>'raw', 'active'=>true, 'ids'=>[11]],
+		$crossEnvironmentDrain
+	);
+})->tag('sql', 'postgresql', 'queue', 'cache', 'data-environment', 'compatibility')->maxMillis(15000);
+
+test('PostgreSQL schema hydration remains isolated to the ambient environment', static function(Context $t): void {
+	dp_sql_postgresql_environment_enabled($t);
+	$t->globalMap('_SESSION')->clear()->put('db_cache_count', 0);
+	foreach(['live', 'sandbox'] as $environment){
+		DataEnvironment::run($environment, static function(): void {
+			dp_sql_postgresql_environment_query('DROP TABLE IF EXISTS dataphyre_sql_environment_hydrated');
+		});
+	}
+
+	$definition=TableDefinition::for('dataphyre_sql_environment_hydrated')
+		->autoIncrement('id')
+		->string('label', 64)->notNull();
+	DataEnvironment::run('sandbox', static function() use ($definition, $t): void {
+		$t->isTrue($definition->hydrate());
+		$t->isTrue(
+			TableDefinition::for('dataphyre_sql_environment_hydrated')
+				->string('note', 64)
+				->hydrateColumn('note')
+		);
+	});
+	DataEnvironment::run('live', static function() use ($t): void {
+		$row=dp_sql_postgresql_environment_query(
+			'SELECT to_regclass(?) AS relation_name',
+			['dataphyre_sql_environment_hydrated']
+		);
+		$t->same(null, $row['relation_name'] ?? null);
+	});
+	DataEnvironment::run('sandbox', static function() use ($t): void {
+		$row=dp_sql_postgresql_environment_query(
+			'SELECT column_name FROM information_schema.columns WHERE table_schema = ? AND table_name = ? AND column_name = ?',
+			['public', 'dataphyre_sql_environment_hydrated', 'note']
+		);
+		$t->same('note', $row['column_name'] ?? null);
+	});
+})->tag('sql', 'postgresql', 'schema', 'hydration', 'data-environment', 'compatibility')->maxMillis(15000);


### PR DESCRIPTION
## Summary
- route implicit SQL operations through the active DataEnvironment while preserving explicit cluster precedence
- isolate SQL caches, schema hydration, and deferred queue execution by environment across PostgreSQL, MySQL, and SQLite
- add an opt-in two-database PostgreSQL compatibility test

## Verification
- PHP 8.2/8.4 syntax checks on all changed runtime files
- real PostgreSQL 17 compatibility test: 3 cases, 25 assertions
- PostgreSQL migration framework: 30 cases, 562 assertions
- SQL framework JSON contracts: 14/14 workers
- DataEnvironment contracts: 3 cases, 34 assertions
- real SQLite environment replay harness
- MCP live validation

## Context
Serve sandbox requests were authenticated correctly but DB::connection() continued using the live database. Serve then failed closed when its sandbox SQL guard observed the live database.