### PR TITLE
Support data-only PostgreSQL migrations

### DIFF
--- a/runtime/modules/mcp/kernel/dataphyre_mcp.client.discovery.php
+++ b/runtime/modules/mcp/kernel/dataphyre_mcp.client.discovery.php
@@ -363,6 +363,9 @@ trait dataphyre_mcp_client_discovery_surfaces {
 			foreach(array_values(array_unique($app_modules)) as $module){
 				$description=$this->describe_module($module, 20);
 				foreach($description['files']['documentation'] ?? [] as $path){
+					if($app_builder_task && $this->docs_chunk_builder_skip_path((string)$path)){
+						continue;
+					}
 					$candidates[]=[
 						'kind'=>'documentation',
 						'id'=>(string)$path,

--- a/runtime/modules/mcp/kernel/dataphyre_mcp.planning.docs.php
+++ b/runtime/modules/mcp/kernel/dataphyre_mcp.planning.docs.php
@@ -197,7 +197,7 @@ trait dataphyre_mcp_planning_docs_surfaces {
 	 */
 	private function docs_chunk_builder_skip_path(string $path): bool {
 		$normalized=strtolower(str_replace('\\', '/', $path));
-		foreach(['capability_audit', 'audit.md', 'roadmap', 'release', 'changelog'] as $needle){
+		foreach(['capability_audit', 'audit.md', 'migration', 'roadmap', 'release', 'changelog'] as $needle){
 			if(str_contains($normalized, $needle)){
 				return true;
 			}

--- a/runtime/modules/sql/Framework/Migrations/PostgreSqlMigrationManifest.php
+++ b/runtime/modules/sql/Framework/Migrations/PostgreSqlMigrationManifest.php
@@ -111,8 +111,12 @@ final class PostgreSqlMigrationManifest {
 			$expectedKeys=$down===null
 				? ['description', 'down', 'id', 'irreversible_reason', 'minimum_compatible_release', 'phase', 'up']
 				: ['description', 'down', 'id', 'minimum_compatible_release', 'phase', 'up'];
+			if(array_key_exists('change_kind', $entry)){
+				array_unshift($expectedKeys, 'change_kind');
+			}
 			$id=$entry['id'] ?? null;
 			$phase=$entry['phase'] ?? null;
+			$changeKind=$entry['change_kind'] ?? 'schema';
 			$description=$entry['description'] ?? null;
 			$minimumCompatibleRelease=$entry['minimum_compatible_release'] ?? null;
 			if(
@@ -126,6 +130,12 @@ final class PostgreSqlMigrationManifest {
 				|| trim($description)===''
 			){
 				throw new RuntimeException('PostgreSQL migration manifest entry identity is invalid.');
+			}
+			if(
+				!is_string($changeKind)
+				|| !in_array($changeKind, PostgreSqlMigrationProfile::CHANGE_KINDS, true)
+			){
+				throw new RuntimeException('Migration change kind is invalid: '.$id.'.');
 			}
 			if($phase==='rolling_contract'){
 				if(!PostgreSqlMigrationProfile::validVersion($minimumCompatibleRelease)){
@@ -200,6 +210,7 @@ final class PostgreSqlMigrationManifest {
 			$entries[]=[
 				'id'=>$id,
 				'phase'=>$phase,
+				'change_kind'=>$changeKind,
 				'up'=>$up,
 				'down'=>$normalizedDown,
 				'irreversible_reason'=>$irreversibleReason,

--- a/runtime/modules/sql/Framework/Migrations/PostgreSqlMigrationProfile.php
+++ b/runtime/modules/sql/Framework/Migrations/PostgreSqlMigrationProfile.php
@@ -23,6 +23,7 @@ final class PostgreSqlMigrationProfile implements JsonSerializable {
 	public const MANIFEST_SCHEMA_VERSION=3;
 	public const PHASES=['bootstrap', 'rolling_expand', 'rolling_contract'];
 	public const DOWN_SAFETY=['lossless', 'data_loss'];
+	public const CHANGE_KINDS=['schema', 'data_only'];
 	private const EVENT_FIXED_COLUMNS=[
 		'event_id',
 		'operation_id',

--- a/runtime/modules/sql/Framework/Migrations/PostgreSqlSchemaInspector.php
+++ b/runtime/modules/sql/Framework/Migrations/PostgreSqlSchemaInspector.php
@@ -599,8 +599,10 @@ final class PostgreSqlSchemaInspector {
 	}
 
 	/**
-	 * Proves a down migration changes structure, preserves rows when labelled
-	 * lossless, and is exactly reconstructed by its paired up migration.
+	 * Proves a schema down migration changes structure, or that an explicitly
+	 * data-only pair leaves structure untouched. The paired up/down directions
+	 * must reconstruct the selected structural and data evidence exactly, and
+	 * lossless directions must preserve application row counts.
 	 *
 	 * The caller owns the surrounding transaction and final commit/rollback.
 	 *
@@ -613,8 +615,15 @@ final class PostgreSqlSchemaInspector {
 				($entry['irreversible_reason'] ?? 'no down migration')
 			);
 		}
+		$changeKind=$entry['change_kind'] ?? 'schema';
+		if(!in_array($changeKind, PostgreSqlMigrationProfile::CHANGE_KINDS, true)){
+			throw new RuntimeException(
+				'Migration change kind is invalid during rollback certification: '.$entry['id'].'.'
+			);
+		}
+		$dataOnly=$changeKind==='data_only';
 		$before=$this->structuralFingerprint($pdo);
-		$beforeData=$entry['down']['safety']==='lossless'
+		$beforeData=$dataOnly || $entry['down']['safety']==='lossless'
 			? $this->dataFingerprint($pdo)
 			: null;
 		self::executeSql(
@@ -623,15 +632,23 @@ final class PostgreSqlSchemaInspector {
 			'Migration down SQL execution failed: '.$entry['id'].'.'
 		);
 		$down=$this->structuralFingerprint($pdo);
-		if(hash_equals($before, $down)){
+		if($dataOnly && !hash_equals($before, $down)){
+			throw new RuntimeException(
+				'Data-only migration down direction changed application structure: '.$entry['id'].'.'
+			);
+		}
+		if(!$dataOnly && hash_equals($before, $down)){
 			throw new RuntimeException(
 				'Migration down direction made no structural change: '.$entry['id'].'.'
 			);
 		}
-		if(is_array($beforeData)){
+		$downData=$dataOnly || is_array($beforeData)
+			? $this->dataFingerprint($pdo)
+			: null;
+		if(is_array($beforeData) && $entry['down']['safety']==='lossless'){
 			self::assertLosslessDownRows(
 				$beforeData,
-				$this->dataFingerprint($pdo),
+				$downData,
 				(string)$entry['id']
 			);
 		}
@@ -647,7 +664,16 @@ final class PostgreSqlSchemaInspector {
 				$entry['id'].'.'
 			);
 		}
-		if(is_array($beforeData) && $beforeData!==$this->dataFingerprint($pdo)){
+		$restoredData=$dataOnly || is_array($beforeData)
+			? $this->dataFingerprint($pdo)
+			: null;
+		if($dataOnly && $beforeData!==$restoredData){
+			throw new RuntimeException(
+				'Data-only migration up direction did not reconstruct pre-rollback data: '.
+				$entry['id'].'.'
+			);
+		}
+		if(!$dataOnly && is_array($beforeData) && $beforeData!==$restoredData){
 			throw new RuntimeException(
 				'Migration labelled lossless did not preserve all application rows through '.
 				'down/up certification: '.$entry['id'].'.'
@@ -659,16 +685,31 @@ final class PostgreSqlSchemaInspector {
 			'Migration final down SQL execution failed during rollback certification: '.$entry['id'].'.'
 		);
 		$final=$this->structuralFingerprint($pdo);
+		if($dataOnly && !hash_equals($before, $final)){
+			throw new RuntimeException(
+				'Data-only migration final down direction changed application structure: '.
+				$entry['id'].'.'
+			);
+		}
 		if(!hash_equals($down, $final)){
 			throw new RuntimeException(
 				'Migration down direction is not repeatably paired with its up migration: '.
 				$entry['id'].'.'
 			);
 		}
-		if(is_array($beforeData)){
+		$finalData=$dataOnly || is_array($beforeData)
+			? $this->dataFingerprint($pdo)
+			: null;
+		if($dataOnly && $downData!==$finalData){
+			throw new RuntimeException(
+				'Data-only migration down direction is not repeatably paired with its up '.
+				'direction: '.$entry['id'].'.'
+			);
+		}
+		if(is_array($beforeData) && $entry['down']['safety']==='lossless'){
 			self::assertLosslessDownRows(
 				$beforeData,
-				$this->dataFingerprint($pdo),
+				$finalData,
 				(string)$entry['id']
 			);
 		}

--- a/runtime/modules/sql/documentation/Dataphyre_PostgreSQL_Migrations.md
+++ b/runtime/modules/sql/documentation/Dataphyre_PostgreSQL_Migrations.md
@@ -73,6 +73,12 @@ manifest tooling use the same pure `sqlSafetyIssues(...)` classification.
 `manifest_public_path` is the release-relative label returned in summaries; it
 does not redirect the filesystem read.
 
+Each manifest entry may declare `"change_kind": "data_only"` when both SQL
+directions intentionally mutate application rows without changing application
+structure. Omitting `change_kind` normalizes to `"schema"`, preserving the
+existing contract for every prior manifest. The only accepted values are
+`schema` and `data_only`; the loader rejects any other classification.
+
 ## Supported schema introspection grammar
 
 Dataphyre's status-time schema contract deliberately models a bounded,
@@ -87,9 +93,11 @@ The final statement in a migration may omit its semicolon. SQL outside this
 grammar can still be valid transactional migration SQL, but it is not silently
 promoted into a schema-drift claim. Views, functions, triggers, policies,
 custom types, privileges, renames, and other specialized objects need
-application-specific verification. A reversible migration whose change is not
-observable by Dataphyre's structural fingerprint fails rollback certification
-instead of being certified from incomplete evidence.
+application-specific verification. A reversible `schema` migration whose
+change is not observable by Dataphyre's structural fingerprint fails rollback
+certification instead of being certified from incomplete evidence. Use
+`data_only` only for row mutation pairs, never to bypass an unsupported schema
+change.
 
 Bootstrap entries are adopted history and are deliberately outside exact
 catalog certification. Dataphyre validates their immutable bytes, replays each
@@ -373,7 +381,12 @@ Before rollback, derive the contiguous applied tail and inspect its declared
 safety. Dataphyre refuses history gaps and checksum drift. Reversible SQL is
 certified inside the runner-owned transaction with a down/up/down sequence:
 
-- structural fingerprints must match after repeated down
+- `schema` migrations must make an observable structural change, reconstruct
+  the original structure after up, and match structural fingerprints after
+  repeated down
+- `data_only` migrations must leave structure unchanged after down, up, and the
+  repeated down; up must restore the exact pre-rollback data fingerprint and
+  both down executions must produce the same data fingerprint
 - `lossless` migrations must preserve row evidence after both down executions
   and reconstruct the original row fingerprints after the intervening up
 - any `PDO::exec(...)` failure aborts certification

--- a/runtime/modules/sql/documentation/postgresql-migration-manifest-v3.schema.json
+++ b/runtime/modules/sql/documentation/postgresql-migration-manifest-v3.schema.json
@@ -114,6 +114,14 @@
             "rolling_contract"
           ]
         },
+        "change_kind": {
+          "enum": [
+            "schema",
+            "data_only"
+          ],
+          "default": "schema",
+          "description": "Classifies reversible certification evidence. Data-only migrations must not change application structure."
+        },
         "up": {
           "$ref": "#/$defs/up"
         },

--- a/runtime/modules/sql/unit_tests/dataphyre.postgresql_migration_framework.test.php
+++ b/runtime/modules/sql/unit_tests/dataphyre.postgresql_migration_framework.test.php
@@ -411,6 +411,7 @@ test('PostgreSQL migration manifests normalize immutable SQL and public evidence
 	$t->same(array_column($raw['migrations'], 'id'), array_column($manifest->entries(), 'id'));
 	$t->same('Fixture bootstrap baseline.', $manifest->entries()[0]['irreversible_reason']);
 	$t->same(null, $manifest->entries()[2]['irreversible_reason']);
+	$t->same('schema', $manifest->entries()[2]['change_kind']);
 	$t->same('lossless', $manifest->entries()[2]['down']['safety']);
 	$t->same(
 		[
@@ -422,6 +423,35 @@ test('PostgreSQL migration manifests normalize immutable SQL and public evidence
 	);
 	$t->same(5, $manifest->publicSummary()['migration_count']);
 	$t->same($manifest->sha256(), $manifest->publicSummary()['sha256']);
+
+	[$dataDatabase]=dp_postgresql_migration_manifest_fixture(
+		$t,
+		'valid-data-only-kind',
+		static function(array &$manifest): void {
+			$manifest['migrations'][2]['change_kind']='data_only';
+		}
+	);
+	$dataManifest=PostgreSqlMigrationManifest::load(
+		$dataDatabase,
+		dp_postgresql_migration_profile()
+	);
+	$t->same('data_only', $dataManifest->entries()[2]['change_kind']);
+	$publishedSchema=json_decode(
+		(string)file_get_contents(
+			dirname(__DIR__).'/documentation/postgresql-migration-manifest-v3.schema.json'
+		),
+		true,
+		512,
+		JSON_THROW_ON_ERROR
+	);
+	$t->same(
+		['schema', 'data_only'],
+		$publishedSchema['$defs']['migration']['properties']['change_kind']['enum'] ?? null
+	);
+	$t->same(
+		'schema',
+		$publishedSchema['$defs']['migration']['properties']['change_kind']['default'] ?? null
+	);
 })->tag('sql', 'migration', 'postgresql', 'manifest')->group('framework-coverage');
 
 test('PostgreSQL migration manifests fail closed on shape phase and direction drift', static function(Context $t): void {
@@ -544,6 +574,12 @@ test('PostgreSQL migration manifests fail closed on shape phase and direction dr
 				$manifest['migrations'][2]['down']['safety']='unknown';
 			},
 			'down safety contract',
+		],
+		'change-kind'=>[
+			static function(array &$manifest): void {
+				$manifest['migrations'][2]['change_kind']='rows';
+			},
+			'change kind is invalid',
 		],
 		'down-extra-key'=>[
 			static function(array &$manifest): void {
@@ -2945,6 +2981,118 @@ test('PostgreSQL schema fingerprints and lossless certification use inspectable 
 		]),
 		RuntimeException::class,
 		'made no structural change'
+	);
+
+	$dataOnly=$t->scriptedPdo('pgsql');
+	dp_postgresql_migration_queue_structure($dataOnly, 'same');
+	dp_postgresql_migration_queue_data($dataOnly, '2', 'before');
+	dp_postgresql_migration_queue_structure($dataOnly, 'same');
+	dp_postgresql_migration_queue_data($dataOnly, '1', 'down');
+	dp_postgresql_migration_queue_structure($dataOnly, 'same');
+	dp_postgresql_migration_queue_data($dataOnly, '2', 'before');
+	dp_postgresql_migration_queue_structure($dataOnly, 'same');
+	dp_postgresql_migration_queue_data($dataOnly, '1', 'down');
+	$inspector->certifyDown($dataOnly, [
+		'id'=>'003_data_backfill',
+		'change_kind'=>'data_only',
+		'up'=>['sql'=>'DATA UP'],
+		'down'=>['sql'=>'DATA DOWN', 'safety'=>'data_loss'],
+	]);
+	$t->same(
+		['DATA DOWN', 'DATA UP', 'DATA DOWN'],
+		array_column(array_values(array_filter(
+			$dataOnly->operations(),
+			static fn(array $operation): bool=>$operation['operation']==='exec'
+		)), 'sql')
+	);
+
+	$dataOnlyStructuralMutation=$t->scriptedPdo('pgsql');
+	dp_postgresql_migration_queue_structure($dataOnlyStructuralMutation, 'before');
+	dp_postgresql_migration_queue_data($dataOnlyStructuralMutation, '2', 'before');
+	dp_postgresql_migration_queue_structure($dataOnlyStructuralMutation, 'changed');
+	$t->throws(
+		static fn()=>$inspector->certifyDown($dataOnlyStructuralMutation, [
+			'id'=>'003_data_backfill',
+			'change_kind'=>'data_only',
+			'up'=>['sql'=>'DATA UP'],
+			'down'=>['sql'=>'DATA DOWN', 'safety'=>'data_loss'],
+		]),
+		RuntimeException::class,
+		'down direction changed application structure'
+	);
+
+	$dataOnlyUpStructuralMutation=$t->scriptedPdo('pgsql');
+	dp_postgresql_migration_queue_structure($dataOnlyUpStructuralMutation, 'same');
+	dp_postgresql_migration_queue_data($dataOnlyUpStructuralMutation, '2', 'before');
+	dp_postgresql_migration_queue_structure($dataOnlyUpStructuralMutation, 'same');
+	dp_postgresql_migration_queue_data($dataOnlyUpStructuralMutation, '1', 'down');
+	dp_postgresql_migration_queue_structure($dataOnlyUpStructuralMutation, 'changed');
+	$t->throws(
+		static fn()=>$inspector->certifyDown($dataOnlyUpStructuralMutation, [
+			'id'=>'003_data_backfill',
+			'change_kind'=>'data_only',
+			'up'=>['sql'=>'DATA UP'],
+			'down'=>['sql'=>'DATA DOWN', 'safety'=>'data_loss'],
+		]),
+		RuntimeException::class,
+		'did not reconstruct the pre-rollback schema'
+	);
+
+	$dataOnlyRestorationMismatch=$t->scriptedPdo('pgsql');
+	dp_postgresql_migration_queue_structure($dataOnlyRestorationMismatch, 'same');
+	dp_postgresql_migration_queue_data($dataOnlyRestorationMismatch, '2', 'before');
+	dp_postgresql_migration_queue_structure($dataOnlyRestorationMismatch, 'same');
+	dp_postgresql_migration_queue_data($dataOnlyRestorationMismatch, '1', 'down');
+	dp_postgresql_migration_queue_structure($dataOnlyRestorationMismatch, 'same');
+	dp_postgresql_migration_queue_data($dataOnlyRestorationMismatch, '2', 'wrong');
+	$t->throws(
+		static fn()=>$inspector->certifyDown($dataOnlyRestorationMismatch, [
+			'id'=>'003_data_backfill',
+			'change_kind'=>'data_only',
+			'up'=>['sql'=>'DATA UP'],
+			'down'=>['sql'=>'DATA DOWN', 'safety'=>'data_loss'],
+		]),
+		RuntimeException::class,
+		'did not reconstruct pre-rollback data'
+	);
+
+	$dataOnlyFinalStructuralMutation=$t->scriptedPdo('pgsql');
+	dp_postgresql_migration_queue_structure($dataOnlyFinalStructuralMutation, 'same');
+	dp_postgresql_migration_queue_data($dataOnlyFinalStructuralMutation, '2', 'before');
+	dp_postgresql_migration_queue_structure($dataOnlyFinalStructuralMutation, 'same');
+	dp_postgresql_migration_queue_data($dataOnlyFinalStructuralMutation, '1', 'down');
+	dp_postgresql_migration_queue_structure($dataOnlyFinalStructuralMutation, 'same');
+	dp_postgresql_migration_queue_data($dataOnlyFinalStructuralMutation, '2', 'before');
+	dp_postgresql_migration_queue_structure($dataOnlyFinalStructuralMutation, 'changed');
+	$t->throws(
+		static fn()=>$inspector->certifyDown($dataOnlyFinalStructuralMutation, [
+			'id'=>'003_data_backfill',
+			'change_kind'=>'data_only',
+			'up'=>['sql'=>'DATA UP'],
+			'down'=>['sql'=>'DATA DOWN', 'safety'=>'data_loss'],
+		]),
+		RuntimeException::class,
+		'final down direction changed application structure'
+	);
+
+	$dataOnlyRepeatMismatch=$t->scriptedPdo('pgsql');
+	dp_postgresql_migration_queue_structure($dataOnlyRepeatMismatch, 'same');
+	dp_postgresql_migration_queue_data($dataOnlyRepeatMismatch, '2', 'before');
+	dp_postgresql_migration_queue_structure($dataOnlyRepeatMismatch, 'same');
+	dp_postgresql_migration_queue_data($dataOnlyRepeatMismatch, '1', 'down');
+	dp_postgresql_migration_queue_structure($dataOnlyRepeatMismatch, 'same');
+	dp_postgresql_migration_queue_data($dataOnlyRepeatMismatch, '2', 'before');
+	dp_postgresql_migration_queue_structure($dataOnlyRepeatMismatch, 'same');
+	dp_postgresql_migration_queue_data($dataOnlyRepeatMismatch, '0', 'different-down');
+	$t->throws(
+		static fn()=>$inspector->certifyDown($dataOnlyRepeatMismatch, [
+			'id'=>'003_data_backfill',
+			'change_kind'=>'data_only',
+			'up'=>['sql'=>'DATA UP'],
+			'down'=>['sql'=>'DATA DOWN', 'safety'=>'data_loss'],
+		]),
+		RuntimeException::class,
+		'not repeatably paired with its up direction'
 	);
 
 	$nondeterministicFinalDown=$t->scriptedPdo('pgsql');


### PR DESCRIPTION
## What

- adds an optional `change_kind` manifest field with `schema` as the compatible default and `data_only` as the explicit row-mutation contract
- certifies data-only rollback pairs without requiring a fake structural change
- proves unchanged structure, exact up restoration, deterministic repeated down state, and existing lossless row guarantees
- publishes the JSON Schema and migration documentation for the new contract

## Why

Serve migration 153 is a legitimate reversible data backfill. The prior framework required every reversible migration to change schema, forcing data-only work into a misleading structural contract and blocking safe rollback certification.

## Verification

- PostgreSQL migration framework: 30 cases, 573 assertions
- PHP syntax checks passed for all changed PHP files
- `git diff --check` passed

The branch was built from clean `origin/main`; unrelated changes in the local authoritative worktree are excluded.
