### PR TITLE
Isolate Vestra Control credentials by operation

### DIFF
--- a/runtime/modules/vestra/documentation/Dataphyre_Vestra_Client.md
+++ b/runtime/modules/vestra/documentation/Dataphyre_Vestra_Client.md
@@ -39,7 +39,19 @@ The owning kernel exposes the merged readonly config as `DP_VESTRA_CFG`.
 - `tenants`
   - Map of Fabric tenant ids or aliases to tenant-specific profile overrides.
     Each profile can set `tenant`, `base_url`, `object_url`, `rate`,
-    `write_token`, `node_token`, token defaults, and `allow_unsigned`.
+    `api_token`, `write_api_token`, `tenant_read_token`, `write_token`,
+    `node_token`, token defaults, and `allow_unsigned`.
+- `api_token`
+  - Vestra Control credential used to mint scoped access tokens. It remains the
+    backwards-compatible fallback for write Control calls when
+    `write_api_token` is omitted.
+- `write_api_token`
+  - Vestra Control credential used only for scoped write-token issuance and
+    object reservation. Dedicated values can carry less authority than the
+    access-side `api_token`.
+- `tenant_read_token`
+  - Pre-issued tenant delivery token used when scoped access-token issuance is
+    unavailable.
 - `write_token`
   - Scoped Vestra write token used by Vestra writes. Dataphyre private keys and
     node tokens are not sent to Vestra object APIs.
@@ -56,6 +68,19 @@ The owning kernel exposes the merged readonly config as `DP_VESTRA_CFG`.
   - Local-development escape hatch for unsigned `/v/...` URLs. Keep this `false`
     for signed Fabric deployments.
 
+Credential inheritance is fail closed per tenant profile. Omitting `api_token`,
+`write_api_token`, `tenant_read_token`, `write_token`, or `node_token` from a
+profile preserves its flat module, legacy application config, and `VESTRA_*`
+environment inheritance chain. When every dedicated `write_api_token` source is
+omitted or empty, write Control calls inherit `api_token` for backwards
+compatibility. Declaring a tenant profile's `write_api_token` as empty or `null`
+explicitly disables that fallback. Declaring any other credential key empty or
+`null` likewise disables inheritance for that credential.
+
+An explicit empty or `null` `write_token` disables both static-token inheritance
+and write-token minting. To mint scoped write tokens with `write_api_token`, omit
+`write_token` from that tenant profile.
+
 Example:
 
 ```php
@@ -64,21 +89,33 @@ return [
 	'object_url'=>'https://vestra.example.com/',
 	'default_tenant'=>'example-store-content',
 	'use_tenant_grant'=>true,
-	'write_token'=>'w1...',
+	'api_token'=>'control.access...',
+	'write_api_token'=>'control.write...',
 	'node_token'=>'node...',
 	'tenants'=>[
 		'example-store-content'=>[
 			'tenant'=>'example-store-content',
 			'rate'=>'s',
-			'write_token'=>'w1...',
+			'api_token'=>'control.access...',
+			'write_api_token'=>'control.write...',
 			'node_token'=>'node...',
 		],
 		'private-app-assets'=>[
 			'tenant'=>'private-app-assets',
 			'rate'=>'internal',
 			'object_url'=>'https://vestra-internal.example.com/',
-			'write_token'=>'w1.internal...',
+			'api_token'=>'control.internal-access...',
+			'write_api_token'=>'control.internal-write...',
 			'node_token'=>'node.internal...',
+		],
+		'isolated-no-credentials'=>[
+			'tenant'=>'isolated-no-credentials',
+			'rate'=>'s',
+			'api_token'=>null,
+			'write_api_token'=>null,
+			'tenant_read_token'=>null,
+			'write_token'=>null,
+			'node_token'=>null,
 		],
 	],
 ];
@@ -88,6 +125,9 @@ return [
 
 The kernel surface is centered around `\dataphyre\vestra`.
 
+- `SEPARATE_CONTROL_CREDENTIALS_VERSION`
+  - Public capability marker. Version `1` guarantees independent `api_token`
+    and `write_api_token` resolution with fail-closed tenant overrides.
 - `configured(): bool`
   - Returns `true` when the module has enough Vestra configuration to operate.
 - `object_url(array $reference, array $parameters=[]): string|false`
@@ -131,6 +171,16 @@ When a reference includes `"tenant": "example-store-content"`, URL generation
 uses the matching `tenants.example-store-content` profile. Callers may also pass
 `['tenant'=>'profile-alias']`; if that profile defines its own `tenant`, the
 profile value becomes the actual Fabric tenant sent to Vestra.
+
+Write operations retain the profile alias for configuration and credential
+lookup, but use that profile's canonical `tenant` in Control endpoint paths,
+write-token scope templates, reservation idempotency, and persisted references.
+This keeps aliases local to application configuration instead of sending them as
+Fabric tenant identities. When the alias differs, propagated references store
+the canonical id in `tenant` and the exact local alias in `tenant_profile` so
+later signing and purge operations can recover the same profile without an
+ambiguous reverse lookup. A marker that does not resolve to the persisted
+canonical tenant is rejected.
 
 Applications that need billing-aware delivery should register dialbacks instead
 of modifying Dataphyre:

--- a/runtime/modules/vestra/kernel/vestra.main.php
+++ b/runtime/modules/vestra/kernel/vestra.main.php
@@ -27,6 +27,7 @@ dp_define_module_config('vestra', 'DP_VESTRA_CFG', [
 	'rate'=>'',
 	'api_url'=>'',
 	'api_token'=>'',
+	'write_api_token'=>'',
 	'api_auth_mode'=>'control_key',
 	'organization'=>'',
 	'ca_bundle'=>'',
@@ -35,6 +36,7 @@ dp_define_module_config('vestra', 'DP_VESTRA_CFG', [
 	'write_token_ttl'=>300,
 	'default_write_max_bytes'=>67108864,
 	'node_token'=>'',
+	'tenant_read_token'=>'',
 	'token_ttl'=>3600,
 	'token_grace'=>60,
 	'use_tenant_grant'=>true,
@@ -61,6 +63,8 @@ if(!is_writable($cache_directory)){
  * counts, rewrites HTML resources, and pushes assets to the configured Vestra API.
  */
 class vestra{
+	/** Public deployment capability marker for split access/write Control credentials. */
+	public const SEPARATE_CONTROL_CREDENTIALS_VERSION=1;
 
 	/**
 	 * Reads a Vestra module configuration value from DP_VESTRA_CFG.
@@ -85,6 +89,24 @@ class vestra{
 	}
 
 	/**
+	 * Resolves the profile map key used for a tenant or the configured default.
+	 *
+	 * @param string $tenant Tenant id or configured profile alias.
+	 * @param array<string,mixed> $config Full Vestra module configuration.
+	 * @return string Resolved profile map key, or an empty string when none is configured.
+	 */
+	private static function tenant_profile_key(string $tenant, array $config): string {
+		$profile_key=trim($tenant);
+		if($profile_key==='' && isset($config['default_tenant'])){
+			$profile_key=trim((string)$config['default_tenant']);
+		}
+		if($profile_key==='' && isset($config['tenant'])){
+			$profile_key=trim((string)$config['tenant']);
+		}
+		return $profile_key;
+	}
+
+	/**
 	 * Resolves a configured tenant profile.
 	 *
 	 * Flat config keys remain the default profile. Entries under `tenants` override
@@ -98,19 +120,89 @@ class vestra{
 		$profile=$config;
 		unset($profile['tenants']);
 		$tenants=is_array($config['tenants'] ?? null) ? $config['tenants'] : [];
-		$tenant=trim($tenant);
-		$profile_key=$tenant;
-		if($profile_key==='' && isset($config['default_tenant'])){
-			$profile_key=trim((string)$config['default_tenant']);
-		}
-		if($profile_key==='' && isset($config['tenant'])){
-			$profile_key=trim((string)$config['tenant']);
-		}
+		$profile_key=self::tenant_profile_key($tenant, $config);
 		if($profile_key!=='' && isset($tenants[$profile_key]) && is_array($tenants[$profile_key])){
 			$profile=array_merge($profile, $tenants[$profile_key]);
 			if(!isset($profile['tenant']) || trim((string)$profile['tenant'])===''){
 				$profile['tenant']=$profile_key;
 			}
+		}
+		return $profile;
+	}
+
+	/**
+	 * Resolves the canonical Fabric tenant while retaining the caller's profile key.
+	 *
+	 * Configuration and credentials continue to resolve through the original alias;
+	 * this value is only for tenant identity sent to Control or persisted in a
+	 * Fabric reference.
+	 *
+	 * @param string $tenant Tenant id or configured profile alias.
+	 * @return string Canonical configured tenant id, or the resolved profile key.
+	 */
+	private static function canonical_tenant(string $tenant=''): string {
+		$config=self::config_all();
+		$profile_key=self::tenant_profile_key($tenant, $config);
+		$tenants=is_array($config['tenants'] ?? null) ? $config['tenants'] : [];
+		if($profile_key!=='' && isset($tenants[$profile_key]) && is_array($tenants[$profile_key])){
+			$canonical=$tenants[$profile_key]['tenant'] ?? null;
+			if(is_scalar($canonical) && trim((string)$canonical)!==''){
+				return trim((string)$canonical);
+			}
+		}
+		return $profile_key;
+	}
+
+	/**
+	 * Builds a tenant-scoped Control route with the canonical Fabric tenant id.
+	 *
+	 * @param string $tenant Tenant id or configured profile alias.
+	 * @param string $suffix Route below `/tenants/{tenant}`.
+	 * @return string Canonical tenant Control path.
+	 */
+	private static function tenant_control_path(string $tenant, string $suffix): string {
+		$canonical=self::canonical_tenant($tenant);
+		return '/tenants/'.rawurlencode($canonical).'/'.ltrim($suffix, '/');
+	}
+
+	/**
+	 * Persists canonical tenant identity and the exact local profile alias separately.
+	 *
+	 * @param array<string,mixed> $reference Vestra Fabric reference.
+	 * @param string $tenant Tenant id or configured profile alias used by the caller.
+	 * @return array<string,mixed> Reference with canonical tenant identity.
+	 */
+	private static function apply_reference_tenant_identity(array $reference, string $tenant): array {
+		$profile_key=self::tenant_profile_key($tenant, self::config_all());
+		$canonical=self::canonical_tenant($profile_key);
+		$reference['tenant']=$canonical;
+		if($profile_key!=='' && $profile_key!==$canonical){
+			$reference['tenant_profile']=$profile_key;
+		}
+		else
+		{
+			unset($reference['tenant_profile']);
+		}
+		return $reference;
+	}
+
+	/**
+	 * Returns the local profile key from a persisted canonical reference.
+	 *
+	 * A mismatched marker is rejected instead of reverse-mapping canonical tenant
+	 * ids to an ambiguous alias.
+	 *
+	 * @param array<string,mixed> $reference Vestra Fabric reference.
+	 * @return string|false Valid profile key/tenant id, or false on identity mismatch.
+	 */
+	private static function reference_tenant_profile(array $reference): string|false {
+		$tenant=isset($reference['tenant']) && is_scalar($reference['tenant']) ? trim((string)$reference['tenant']) : '';
+		if(!array_key_exists('tenant_profile', $reference)){
+			return $tenant;
+		}
+		$profile=is_scalar($reference['tenant_profile']) ? trim((string)$reference['tenant_profile']) : '';
+		if($profile==='' || $tenant==='' || self::canonical_tenant($profile)!==$tenant){
+			return false;
 		}
 		return $profile;
 	}
@@ -126,6 +218,31 @@ class vestra{
 	private static function profile_config(string $key, string $tenant='', mixed $default=null): mixed {
 		$profile=self::tenant_profile($tenant);
 		return $profile[$key] ?? self::config($key, $default);
+	}
+
+	/**
+	 * Reads an explicitly declared tenant-profile credential without inheriting.
+	 *
+	 * Presence is intentionally tracked separately from value. An empty, null, or
+	 * otherwise non-scalar credential is an explicit fail-closed override, while an
+	 * omitted credential remains eligible for the backwards-compatible fallback chain.
+	 *
+	 * @param string $key Credential config key.
+	 * @param string $tenant Tenant id or configured profile alias.
+	 * @return array{declared:bool,value:string} Explicit override state and normalized value.
+	 */
+	private static function tenant_credential_override(string $key, string $tenant=''): array {
+		$config=self::config_all();
+		$profile_key=self::tenant_profile_key($tenant, $config);
+		$tenants=is_array($config['tenants'] ?? null) ? $config['tenants'] : [];
+		if($profile_key==='' || !isset($tenants[$profile_key]) || !is_array($tenants[$profile_key]) || !array_key_exists($key, $tenants[$profile_key])){
+			return ['declared'=>false, 'value'=>''];
+		}
+		$value=$tenants[$profile_key][$key];
+		return [
+			'declared'=>true,
+			'value'=>is_scalar($value) ? trim((string)$value) : '',
+		];
 	}
 
 	/**
@@ -249,6 +366,10 @@ class vestra{
 	 * @return string Configured Vestra write token, or an empty string.
 	 */
 	private static function vestra_api_token(string $tenant=''): string {
+		$override=self::tenant_credential_override('api_token', $tenant);
+		if($override['declared']){
+			return $override['value'];
+		}
 		$token=trim((string)self::profile_config('api_token', $tenant, ''));
 		if($token==='' && defined('\CFG') && is_array(\CFG)){
 			$token=trim((string)(\CFG['vestra_api_token'] ?? ''));
@@ -262,7 +383,40 @@ class vestra{
 		return $token;
 	}
 
+	/**
+	 * Returns the Control credential authorized for write-token and reserve routes.
+	 *
+	 * A tenant profile may explicitly deny inherited write authority with an empty
+	 * or null `write_api_token`. When the key is omitted, the dedicated flat and
+	 * legacy sources are checked before falling back to `api_token` for backwards
+	 * compatibility.
+	 *
+	 * @param string $tenant Tenant id or configured profile alias.
+	 * @return string Configured Control write credential, or an empty string.
+	 */
+	private static function vestra_write_api_token(string $tenant=''): string {
+		$override=self::tenant_credential_override('write_api_token', $tenant);
+		if($override['declared']){
+			return $override['value'];
+		}
+		$token=trim((string)self::profile_config('write_api_token', $tenant, ''));
+		if($token==='' && defined('\CFG') && is_array(\CFG)){
+			$token=trim((string)(\CFG['vestra_write_api_token'] ?? ''));
+		}
+		if($token==='' && function_exists('\config')){
+			$token=trim((string)\config('vestra_write_api_token'));
+		}
+		if($token===''){
+			$token=trim((string)(getenv('VESTRA_WRITE_API_TOKEN') ?: ''));
+		}
+		return $token!=='' ? $token : self::vestra_api_token($tenant);
+	}
+
 	private static function vestra_tenant_read_token(string $tenant=''): string {
+		$override=self::tenant_credential_override('tenant_read_token', $tenant);
+		if($override['declared']){
+			return $override['value'];
+		}
 		$token=trim((string)self::profile_config('tenant_read_token', $tenant, ''));
 		if($token==='' && defined('\CFG') && is_array(\CFG)){
 			$token=trim((string)(\CFG['vestra_tenant_read_token'] ?? ''));
@@ -332,6 +486,25 @@ class vestra{
 	}
 
 	/**
+	 * Resolves the credential family for a Vestra Control route.
+	 *
+	 * @param string $path Control API route relative to `/api`.
+	 * @param string $tenant Tenant/profile context for credentials.
+	 * @param array<string,mixed> $credentials Explicit request credentials.
+	 * @return string Selected Control credential, or an empty string.
+	 */
+	private static function control_api_token(string $path, string $tenant='', array $credentials=[]): string {
+		$path='/'.ltrim(trim($path), '/');
+		$uses_write_api_token=preg_match('#^/tenants/[^/]+/(?:tokens/write|objects/reserve)/?$#', $path)===1;
+		$key=$uses_write_api_token ? 'write_api_token' : 'api_token';
+		if(array_key_exists($key, $credentials)){
+			$value=$credentials[$key];
+			return is_scalar($value) ? trim((string)$value) : '';
+		}
+		return $uses_write_api_token ? self::vestra_write_api_token($tenant) : self::vestra_api_token($tenant);
+	}
+
+	/**
 	 * Sends a request to the public Vestra Control API.
 	 *
 	 * @param string $method HTTP method.
@@ -340,6 +513,7 @@ class vestra{
 	 * @param string $tenant Tenant/profile context for credentials.
 	 * @param string $idempotency_key Optional idempotency key.
 	 * @param string $encoding Body encoding. Use `form` for tenant control routes that parse form input.
+	 * @param array<string,mixed> $credentials Explicit request-scoped Control credentials.
 	 * @return array<string,mixed>|false Decoded envelope or false on transport failure.
 	 */
 	private static function control_request(string $method, string $path, array $payload=[], string $tenant='', string $idempotency_key='', string $encoding='json', array $credentials=[]): array|false {
@@ -347,10 +521,7 @@ class vestra{
 		if($api_url===''){
 			$api_url=self::api_url($tenant);
 		}
-		$api_token=isset($credentials['api_token']) && is_scalar($credentials['api_token']) ? trim((string)$credentials['api_token']) : '';
-		if($api_token===''){
-			$api_token=self::vestra_api_token($tenant);
-		}
+		$api_token=self::control_api_token($path, $tenant, $credentials);
 		$api_auth_mode=isset($credentials['api_auth_mode']) && is_scalar($credentials['api_auth_mode']) ? strtolower(trim((string)$credentials['api_auth_mode'])) : self::api_auth_mode($tenant);
 		if($api_url==='' || $api_token===''){
 			return false;
@@ -398,7 +569,31 @@ class vestra{
 	}
 
 	/**
-	 * Returns a scoped write token, minting one from the configured API token when needed.
+	 * Resolves only configured write credentials without minting a scoped token.
+	 *
+	 * @param string $tenant Tenant id or configured profile alias.
+	 * @return array{declared:bool,value:string} Profile declaration state and configured token.
+	 */
+	private static function configured_write_token(string $tenant=''): array {
+		$override=self::tenant_credential_override('write_token', $tenant);
+		if($override['declared']){
+			return $override;
+		}
+		$token=trim((string)self::profile_config('write_token', $tenant, ''));
+		if($token==='' && defined('\CFG') && is_array(\CFG)){
+			$token=trim((string)(\CFG['vestra_write_token'] ?? ''));
+		}
+		if($token==='' && function_exists('\config')){
+			$token=trim((string)\config('vestra_write_token'));
+		}
+		if($token===''){
+			$token=trim((string)(getenv('VESTRA_WRITE_TOKEN') ?: ''));
+		}
+		return ['declared'=>false, 'value'=>$token];
+	}
+
+	/**
+	 * Returns a scoped write token, minting one with the write Control credential when needed.
 	 *
 	 * @param string $tenant Tenant id or profile alias.
 	 * @param string $method HTTP method being authorized.
@@ -407,22 +602,9 @@ class vestra{
 	 * @return string Configured or freshly issued Vestra write token.
 	 */
 	private static function vestra_write_token(string $tenant='', string $method='PUT', string $path='', array $context=[]): string {
-		$token=trim((string)self::profile_config('write_token', $tenant, ''));
-		if($token==='' && defined('\CFG') && is_array(\CFG)){
-			$token=trim((string)(\CFG['vestra_write_token'] ?? \CFG['vestra_write_token'] ?? ''));
-		}
-		if($token==='' && function_exists('\config')){
-			$token=trim((string)(\config('vestra_write_token') ?: \config('vestra_write_token')));
-		}
-		if($token===''){
-			$token=trim((string)(getenv('VESTRA_WRITE_TOKEN') ?: ''));
-		}
-		if($token!==''){
-			return $token;
-		}
-		$api_token=self::vestra_api_token($tenant);
-		if($api_token===''){
-			return '';
+		$configured=self::configured_write_token($tenant);
+		if($configured['declared'] || $configured['value']!==''){
+			return $configured['value'];
 		}
 		$rate=trim((string)($context['rate'] ?? self::rate($tenant)));
 		$scope_path=self::write_token_path($path, $tenant, $rate, $context);
@@ -438,8 +620,9 @@ class vestra{
 		if($path===''){
 			$path='/v/{tenant}/{rate}/*';
 		}
+		$canonical_tenant=self::canonical_tenant($tenant);
 		return strtr($path, [
-			'{tenant}'=>$tenant,
+			'{tenant}'=>$canonical_tenant,
 			'{rate}'=>$rate,
 			'{plan}'=>$rate,
 			'{blockid}'=>'*',
@@ -483,7 +666,8 @@ class vestra{
 			unset($cache[$key]);
 		}
 		$api_url=self::api_url($tenant);
-		$api_token=self::vestra_api_token($tenant);
+		$control_path=self::tenant_control_path($tenant, 'tokens/write');
+		$api_token=self::control_api_token($control_path, $tenant);
 		if($api_url==='' || $api_token===''){
 			return '';
 		}
@@ -501,7 +685,7 @@ class vestra{
 		}
 		$curl=curl_init();
 		self::configure_curl_tls($curl, $tenant);
-		curl_setopt($curl, CURLOPT_URL, rtrim($api_url, '/').'/tenants/'.rawurlencode($tenant).'/tokens/write');
+		curl_setopt($curl, CURLOPT_URL, rtrim($api_url, '/').$control_path);
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'POST');
 		$headers=[
@@ -652,6 +836,10 @@ class vestra{
 	 * @return string Configured Vestra node token, or an empty string.
 	 */
 	private static function vestra_node_token(string $tenant=''): string {
+		$override=self::tenant_credential_override('node_token', $tenant);
+		if($override['declared']){
+			return $override['value'];
+		}
 		$token=trim((string)self::profile_config('node_token', $tenant, ''));
 		if($token==='' && defined('\CFG') && is_array(\CFG)){
 			$token=trim((string)(\CFG['vestra_node_token'] ?? ''));
@@ -897,10 +1085,20 @@ class vestra{
 				}
 			}
 		}
-		$reference=[
-			'driver'=>'vestra',
-			'tenant'=>(string)($source['tenant'] ?? $response['tenant'] ?? $metadata['tenant'] ?? self::tenant()),
-		];
+		$reference_tenant_value=$source['tenant'] ?? $response['tenant'] ?? $metadata['tenant'] ?? self::tenant();
+		if(!is_scalar($reference_tenant_value)){
+			return false;
+		}
+		$reference_tenant=trim((string)$reference_tenant_value);
+		$reference_profile_value=$source['tenant_profile'] ?? $response['tenant_profile'] ?? $metadata['tenant_profile'] ?? $reference_tenant;
+		if(!is_scalar($reference_profile_value)){
+			return false;
+		}
+		$reference_profile=trim((string)$reference_profile_value);
+		$reference=self::apply_reference_tenant_identity(['driver'=>'vestra'], $reference_profile);
+		if($reference_tenant!=='' && self::canonical_tenant($reference_tenant)!==$reference['tenant']){
+			return false;
+		}
 		if($object_id!==false){
 			$reference['object_id']=$object_id;
 			$reference['fabric']=[
@@ -989,11 +1187,12 @@ class vestra{
 	}
 
 	private static function fabric_reserve_upload(string $file, string $hash, string $tenant, int $bytes, string $content_type): array|false {
-		if($tenant===''){
+		$canonical_tenant=self::canonical_tenant($tenant);
+		if($canonical_tenant===''){
 			return false;
 		}
 		$object_key=self::safe_object_key($file, $hash);
-		$idempotency_key='dataphyre_'.$tenant.'_'.substr(hash('sha256', implode('|', [$tenant, $object_key, (string)$bytes, $hash])), 0, 40);
+		$idempotency_key='dataphyre_'.$canonical_tenant.'_'.substr(hash('sha256', implode('|', [$canonical_tenant, $object_key, (string)$bytes, $hash])), 0, 40);
 		$rate=self::rate($tenant);
 		$payload=[
 			'object_key'=>$object_key,
@@ -1006,7 +1205,7 @@ class vestra{
 			'checksum_sha256'=>$hash,
 			'idempotency_key'=>$idempotency_key,
 		];
-		$response=self::control_request('POST', '/tenants/'.rawurlencode($tenant).'/objects/reserve', $payload, $tenant, $idempotency_key, 'form');
+		$response=self::control_request('POST', self::tenant_control_path($tenant, 'objects/reserve'), $payload, $tenant, $idempotency_key, 'form');
 		if(!is_array($response) || (($response['ok'] ?? false)===false)){
 			tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T='Vestra Fabric reserve failed: '.json_encode([
 				'code'=>is_array($response) ? ($response['code'] ?? null) : null,
@@ -1036,6 +1235,7 @@ class vestra{
 		}
 		$reference=self::reference_from_response($combined, $hash);
 		if($reference!==false){
+			$reference=self::apply_reference_tenant_identity($reference, $tenant);
 			$reference['filename']=basename($file);
 			$reference['mime_type']=$content_type;
 			$reference['filesize']=$bytes;
@@ -1237,18 +1437,45 @@ class vestra{
 	 * @return array<string,mixed>|false Tenant context, or false when tenant is unknown.
 	 */
 	private static function tenant_context(array $reference, array $parameters=[]): array|false {
-		$context=[
-			'tenant'=>(string)($parameters['tenant'] ?? $reference['tenant'] ?? self::tenant()),
-		];
-		$profile=self::tenant_profile($context['tenant']);
-		$context['tenant']=(string)($profile['tenant'] ?? $parameters['tenant'] ?? $reference['tenant'] ?? $context['tenant']);
-		$context['rate']=(string)($parameters['rate'] ?? $parameters['plan'] ?? $reference['rate'] ?? $profile['rate'] ?? self::rate($context['tenant']));
+		if(array_key_exists('tenant_profile', $parameters) || array_key_exists('tenant', $parameters)){
+			$profile_value=$parameters['tenant_profile'] ?? $parameters['tenant'] ?? '';
+			$profile_key=is_scalar($profile_value) ? trim((string)$profile_value) : '';
+		}
+		else
+		{
+			$profile_key=self::reference_tenant_profile($reference);
+			if($profile_key===false){
+				return false;
+			}
+		}
+		if($profile_key===''){
+			$profile_key=self::tenant();
+		}
+		$canonical_tenant=self::canonical_tenant($profile_key);
+		if($canonical_tenant===''){
+			return false;
+		}
+		if(isset($parameters['tenant']) && is_scalar($parameters['tenant']) && self::canonical_tenant((string)$parameters['tenant'])!==$canonical_tenant){
+			return false;
+		}
+		$context=['tenant'=>$canonical_tenant];
+		if($profile_key!==$canonical_tenant){
+			$context['tenant_profile']=$profile_key;
+		}
+		$profile=self::tenant_profile($profile_key);
+		$context['rate']=(string)($parameters['rate'] ?? $parameters['plan'] ?? $reference['rate'] ?? $profile['rate'] ?? self::rate($profile_key));
 		$context['expires_in_secs']=(int)($parameters['expires_in_secs'] ?? $profile['token_ttl'] ?? self::config('token_ttl', 3600));
 		$context['grace_secs']=(int)($parameters['grace_secs'] ?? $profile['token_grace'] ?? self::config('token_grace', 60));
 		$context['tenant_grant']=(bool)($parameters['tenant_grant'] ?? $profile['use_tenant_grant'] ?? self::config('use_tenant_grant', false));
-		foreach(['base_url', 'object_url', 'api_url', 'api_token', 'api_auth_mode', 'node_token', 'write_token', 'tenant_read_token', 'allow_unsigned'] as $key){
+		foreach(['base_url', 'object_url', 'api_url', 'api_token', 'write_api_token', 'api_auth_mode', 'node_token', 'write_token', 'tenant_read_token', 'allow_unsigned'] as $key){
 			if(isset($parameters[$key])){
 				$context[$key]=$parameters[$key];
+			}
+			elseif(in_array($key, ['api_token', 'write_api_token', 'node_token', 'write_token', 'tenant_read_token'], true)){
+				$override=self::tenant_credential_override($key, $profile_key);
+				if($override['declared']){
+					$context[$key]=$override['value'];
+				}
 			}
 			elseif(isset($profile[$key])){
 				$context[$key]=$profile[$key];
@@ -1273,8 +1500,11 @@ class vestra{
 		if(isset($context['object_expires_at'])){
 			$context['tenant_grant']=false;
 		}
-		$context['tenant']=trim((string)($context['tenant'] ?? ''));
+		$context['tenant']=self::canonical_tenant(trim((string)($context['tenant'] ?? '')));
 		$context['rate']=trim((string)($context['rate'] ?? ''));
+		if(isset($context['tenant_profile']) && self::canonical_tenant((string)$context['tenant_profile'])!==$context['tenant']){
+			return false;
+		}
 		if($context['tenant']==='' || $context['rate']===''){
 			return false;
 		}
@@ -1513,7 +1743,7 @@ class vestra{
 			$query['passkey']=(string)$passkey;
 		}
 		foreach($parameters as $key=>$value){
-			if(in_array($key, ['tenant', 'rate', 'plan', 'base_url', 'object_url', 'api_url', 'api_token', 'api_auth_mode', 'node_token', 'write_token', 'tenant_read_token', 'allow_unsigned', 'expires_in_secs', 'grace_secs', 'tenant_grant', 'token', 'filename', 'passkey'], true)){
+			if(in_array($key, ['tenant', 'tenant_profile', 'rate', 'plan', 'base_url', 'object_url', 'api_url', 'api_token', 'write_api_token', 'api_auth_mode', 'node_token', 'write_token', 'tenant_read_token', 'allow_unsigned', 'expires_in_secs', 'grace_secs', 'tenant_grant', 'token', 'filename', 'passkey'], true)){
 				continue;
 			}
 			if(isset($transform_path['consumed'][$key]) && is_array($token) && isset($token['token']) && trim((string)$token['token'])!==''){
@@ -1634,10 +1864,13 @@ class vestra{
 			}
 			else
 			{
-				$tenant=is_array($reference) ? (string)($reference['tenant'] ?? '') : '';
-				$decoded_result=self::vestra_request('DELETE', '/objects/'.$object_id, [], 'write', $tenant, [
+				$profile_key=is_array($reference) ? self::reference_tenant_profile($reference) : self::tenant();
+				if($profile_key===false){
+					return false;
+				}
+				$decoded_result=self::vestra_request('DELETE', '/objects/'.$object_id, [], 'write', $profile_key, [
 					'max_bytes'=>1,
-					'rate'=>self::rate($tenant),
+					'rate'=>self::rate($profile_key),
 				]);
 				if(is_array($decoded_result) && ($decoded_result['status'] ?? '')==="success"){
 					return 0;
@@ -1891,6 +2124,7 @@ class vestra{
 				}
 				return false;
 			}
+			$reference=self::apply_reference_tenant_identity($reference, $tenant);
 		}
 		if($encrypted_metadata!==[]){
 			$reference['metadata']=array_merge(is_array($reference['metadata'] ?? null) ? $reference['metadata'] : [], $encrypted_metadata);

--- a/runtime/modules/vestra/unit_tests/dataphyre.vestra.tenant_credentials.test.php
+++ b/runtime/modules/vestra/unit_tests/dataphyre.vestra.tenant_credentials.test.php
@@ -1,0 +1,492 @@
+<?php
+/*************************************************************************
+ * Dataphyre
+ *
+ * Copyright (c) 2026 Dataphyre
+ * SPDX-License-Identifier: MIT
+ */
+declare(strict_types=1);
+
+namespace {
+	if(!function_exists('tracelog')){
+		function tracelog(...$args): void {}
+	}
+	if(!function_exists('dp_define_module_config')){
+		function dp_define_module_config(string $module, string $constant, array $config): void {
+			if(!defined($constant)){
+				define($constant, $config);
+			}
+		}
+	}
+	if(!function_exists('sql_define_table')){
+		function sql_define_table(...$args): void {}
+	}
+	if(!function_exists('config')){
+		function config(string $key): mixed {
+			if($key==='vestra_write_token' && empty($GLOBALS['dataphyre_vestra_disable_legacy_write_token'])){
+				return 'config-write-fallback';
+			}
+			return '';
+		}
+	}
+
+	if(!defined('CFG')){
+		define('CFG', [
+			'vestra_tenant_read_token'=>'legacy-read-fallback',
+		]);
+	}
+	if(!defined('DP_VESTRA_CFG')){
+		define('DP_VESTRA_CFG', [
+			'base_url'=>'https://vestra.example.test/',
+			'object_url'=>'https://vestra.example.test/',
+			'api_url'=>'https://control.example.test/api/',
+			'api_token'=>'flat-api-fallback',
+			'write_api_token'=>'',
+			'tenant_read_token'=>'',
+			'write_token'=>'',
+			'node_token'=>'',
+			'default_tenant'=>'empty-profile',
+			'rate'=>'s',
+			'tenants'=>[
+				'empty-profile'=>[
+					'tenant'=>'empty-canonical',
+					'rate'=>'s',
+					'api_token'=>'',
+					'write_api_token'=>'',
+					'tenant_read_token'=>'',
+					'write_token'=>'',
+					'node_token'=>'',
+				],
+				'null-profile'=>[
+					'tenant'=>'null-canonical',
+					'rate'=>'s',
+					'api_token'=>null,
+					'write_api_token'=>null,
+					'tenant_read_token'=>null,
+					'write_token'=>null,
+					'node_token'=>null,
+				],
+				'omitted-profile'=>[
+					'tenant'=>'omitted-canonical',
+					'rate'=>'s',
+				],
+				'partial-profile'=>[
+					'tenant'=>'partial-canonical',
+					'rate'=>'s',
+					'api_token'=>null,
+				],
+				'split-profile'=>[
+					'tenant'=>'split-canonical',
+					'rate'=>'s',
+					'api_token'=>'access-control-token',
+					'write_api_token'=>'write-control-token',
+				],
+				'write-only-profile'=>[
+					'tenant'=>'write-only-canonical',
+					'rate'=>'s',
+					'api_token'=>null,
+					'write_api_token'=>'write-only-control-token',
+				],
+				'write-api-denied-profile'=>[
+					'tenant'=>'write-api-denied-canonical',
+					'rate'=>'s',
+					'api_token'=>'access-control-token',
+					'write_api_token'=>null,
+				],
+				'write-token-denied-profile'=>[
+					'tenant'=>'write-token-denied-canonical',
+					'rate'=>'s',
+					'api_token'=>null,
+					'write_api_token'=>'write-control-token',
+					'write_token'=>null,
+				],
+			],
+		]);
+	}
+
+	putenv('VESTRA_API_TOKEN=environment-api-fallback');
+	putenv('VESTRA_WRITE_API_TOKEN');
+	putenv('VESTRA_TENANT_READ_TOKEN=environment-read-fallback');
+	putenv('VESTRA_WRITE_TOKEN=environment-write-fallback');
+	putenv('VESTRA_NODE_TOKEN=environment-node-fallback');
+}
+
+namespace dataphyre {
+	function curl_init(?string $url=null): \CurlHandle|false {
+		return \curl_init($url);
+	}
+
+	function curl_setopt(\CurlHandle $handle, int $option, mixed $value): bool {
+		$id=spl_object_id($handle);
+		$GLOBALS['dataphyre_vestra_curl_options'][$id][$option]=$value;
+		return true;
+	}
+
+	function curl_exec(\CurlHandle $handle): string|bool {
+		$id=spl_object_id($handle);
+		$GLOBALS['dataphyre_vestra_curl_calls'][]=$GLOBALS['dataphyre_vestra_curl_options'][$id] ?? [];
+		if(is_array($GLOBALS['dataphyre_vestra_curl_responses'] ?? null) && $GLOBALS['dataphyre_vestra_curl_responses']!==[]){
+			return (string)array_shift($GLOBALS['dataphyre_vestra_curl_responses']);
+		}
+		return (string)($GLOBALS['dataphyre_vestra_curl_response'] ?? '{"ok":false}');
+	}
+
+	function curl_getinfo(\CurlHandle $handle, ?int $option=null): mixed {
+		return $option===CURLINFO_RESPONSE_CODE ? 200 : [];
+	}
+
+	function curl_close(\CurlHandle $handle): void {
+		unset($GLOBALS['dataphyre_vestra_curl_options'][spl_object_id($handle)]);
+		\curl_close($handle);
+	}
+
+	function curl_error(\CurlHandle $handle): string {
+		return '';
+	}
+
+	if(!class_exists(__NAMESPACE__.'\core', false)){
+		final class core {
+			public static function dialback(string $event_name, mixed ...$data): mixed {
+				return null;
+			}
+		}
+	}
+}
+
+namespace DataphyreUnitTests {
+	use Dataphyre\Test\Context;
+	use ReflectionClass;
+	use function Dataphyre\Test\test;
+
+	require_once __DIR__.'/../kernel/vestra.main.php';
+
+	/** @param list<mixed> $arguments */
+	function vestra_private_call(string $method, array $arguments=[]): mixed {
+		$reflection=new ReflectionClass(\dataphyre\vestra::class);
+		return $reflection->getMethod($method)->invokeArgs(null, $arguments);
+	}
+
+	/** @return array{api_token:string,write_api_token:string,tenant_read_token:string,write_token:string,node_token:string} */
+	function vestra_resolved_credentials(string $profile): array {
+		return [
+			'api_token'=>(string)vestra_private_call('vestra_api_token', [$profile]),
+			'write_api_token'=>(string)vestra_private_call('vestra_write_api_token', [$profile]),
+			'tenant_read_token'=>(string)vestra_private_call('vestra_tenant_read_token', [$profile]),
+			'write_token'=>(string)vestra_private_call('vestra_write_token', [$profile]),
+			'node_token'=>(string)vestra_private_call('vestra_node_token', [$profile]),
+		];
+	}
+
+	/** @param list<string> $responses */
+	function vestra_reset_http_spy(array $responses=[]): void {
+		$GLOBALS['dataphyre_vestra_curl_options']=[];
+		$GLOBALS['dataphyre_vestra_curl_calls']=[];
+		$GLOBALS['dataphyre_vestra_curl_responses']=$responses;
+		$GLOBALS['dataphyre_vestra_curl_response']=json_encode([
+			'ok'=>true,
+			'data'=>[
+				'write_token'=>[
+					'token'=>'w1.minted-test',
+					'expires_at'=>4102444800,
+				],
+			],
+		], JSON_UNESCAPED_SLASHES);
+	}
+
+	/** @return list<array<int,mixed>> */
+	function vestra_http_calls(): array {
+		return is_array($GLOBALS['dataphyre_vestra_curl_calls'] ?? null) ? $GLOBALS['dataphyre_vestra_curl_calls'] : [];
+	}
+
+	function vestra_without_legacy_write_token(callable $callback): mixed {
+		$had_flag=array_key_exists('dataphyre_vestra_disable_legacy_write_token', $GLOBALS);
+		$previous_flag=$GLOBALS['dataphyre_vestra_disable_legacy_write_token'] ?? null;
+		$previous_environment=getenv('VESTRA_WRITE_TOKEN');
+		$GLOBALS['dataphyre_vestra_disable_legacy_write_token']=true;
+		putenv('VESTRA_WRITE_TOKEN');
+		try{
+			return $callback();
+		}
+		finally{
+			if($had_flag){
+				$GLOBALS['dataphyre_vestra_disable_legacy_write_token']=$previous_flag;
+			}
+			else
+			{
+				unset($GLOBALS['dataphyre_vestra_disable_legacy_write_token']);
+			}
+			$previous_environment===false
+				? putenv('VESTRA_WRITE_TOKEN')
+				: putenv('VESTRA_WRITE_TOKEN='.$previous_environment);
+		}
+	}
+
+	test('explicit empty tenant credentials suppress every fallback source', static function(Context $t): void {
+		$expected=[
+			'api_token'=>'',
+			'write_api_token'=>'',
+			'tenant_read_token'=>'',
+			'write_token'=>'',
+			'node_token'=>'',
+		];
+		$t->same($expected, vestra_resolved_credentials('empty-profile'));
+		$t->same($expected, vestra_resolved_credentials(''));
+	})->tag('vestra', 'credentials', 'tenant-isolation');
+
+	test('explicit null tenant credentials fail closed and survive profile aliases', static function(Context $t): void {
+		$expected=[
+			'api_token'=>'',
+			'write_api_token'=>'',
+			'tenant_read_token'=>'',
+			'write_token'=>'',
+			'node_token'=>'',
+		];
+		$t->same($expected, vestra_resolved_credentials('null-profile'));
+
+		$context=vestra_private_call('tenant_context', [['tenant'=>'null-profile'], []]);
+		$t->same('null-canonical', $context['tenant'] ?? null);
+		foreach(array_keys($expected) as $key){
+			$t->isTrue(array_key_exists($key, $context));
+			$t->same('', $context[$key]);
+		}
+	})->tag('vestra', 'credentials', 'tenant-isolation');
+
+	test('omitted tenant credentials retain backwards-compatible inheritance', static function(Context $t): void {
+		$expected=[
+			'api_token'=>'flat-api-fallback',
+			'write_api_token'=>'flat-api-fallback',
+			'tenant_read_token'=>'legacy-read-fallback',
+			'write_token'=>'config-write-fallback',
+			'node_token'=>'environment-node-fallback',
+		];
+		$t->same($expected, vestra_resolved_credentials('omitted-profile'));
+
+		$context=vestra_private_call('tenant_context', [['tenant'=>'omitted-profile'], []]);
+		$t->same('omitted-canonical', $context['tenant'] ?? null);
+		foreach(array_keys($expected) as $key){
+			$t->isFalse(array_key_exists($key, $context));
+		}
+	})->tag('vestra', 'credentials', 'compatibility');
+
+	test('credential inheritance is decided independently per profile key', static function(Context $t): void {
+		$t->same([
+			'api_token'=>'',
+			'write_api_token'=>'',
+			'tenant_read_token'=>'legacy-read-fallback',
+			'write_token'=>'config-write-fallback',
+			'node_token'=>'environment-node-fallback',
+		], vestra_resolved_credentials('partial-profile'));
+	})->tag('vestra', 'credentials', 'compatibility');
+
+	test('split Control credentials route access and write authority independently', static function(Context $t): void {
+		$t->same(1, \dataphyre\vestra::SEPARATE_CONTROL_CREDENTIALS_VERSION);
+		$write_path=vestra_private_call('tenant_control_path', ['split-profile', 'tokens/write']);
+		$reserve_path=vestra_private_call('tenant_control_path', ['split-profile', 'objects/reserve']);
+		$t->same('/tenants/split-canonical/tokens/write', $write_path);
+		$t->same('/tenants/split-canonical/objects/reserve', $reserve_path);
+		$t->same('access-control-token', vestra_private_call('control_api_token', [
+			'/tenants/split-canonical/tokens/access',
+			'split-profile',
+		]));
+		$t->same('write-control-token', vestra_private_call('control_api_token', [
+			$write_path,
+			'split-profile',
+		]));
+		$t->same('write-control-token', vestra_private_call('control_api_token', [
+			$reserve_path,
+			'split-profile',
+		]));
+		$t->same('/v/split-canonical/s/*', vestra_private_call('write_token_path', [
+			'/v/{tenant}/{rate}/*',
+			'split-profile',
+			's',
+		]));
+		$reference=vestra_private_call('reference_from_response', [[
+			'ok'=>true,
+			'tenant'=>'split-profile',
+			'data'=>['object_id'=>123456789],
+		]]);
+		$t->same('split-canonical', $reference['tenant'] ?? null);
+		$t->same('split-profile', $reference['tenant_profile'] ?? null);
+		$t->same('split-profile', vestra_private_call('reference_tenant_profile', [$reference]));
+
+		vestra_reset_http_spy([
+			json_encode([
+				'ok'=>true,
+				'data'=>[
+					'access_token'=>[
+						'token'=>'g1.access-test',
+						'expires_at'=>4102444800,
+					],
+				],
+			], JSON_THROW_ON_ERROR|JSON_UNESCAPED_SLASHES),
+		]);
+		$t->same(
+			'https://vestra.example.test/v/split-canonical/s/123456789/t/g1.access-test/object-123456789.jpg',
+			\dataphyre\vestra::asset_url($reference, 'jpg')
+		);
+		$calls=vestra_http_calls();
+		$t->count(1, $calls);
+		$t->same('https://control.example.test/api/tenants/split-canonical/tokens/access', $calls[0][CURLOPT_URL] ?? null);
+		$headers=is_array($calls[0][CURLOPT_HTTPHEADER] ?? null) ? $calls[0][CURLOPT_HTTPHEADER] : [];
+		$t->isTrue(in_array('X-Vestra-Control-Key: access-control-token', $headers, true));
+
+		vestra_reset_http_spy();
+		$t->type('array', vestra_private_call('control_request', [
+			'POST',
+			$reserve_path,
+			[],
+			'split-profile',
+			'',
+			'form',
+		]));
+		$calls=vestra_http_calls();
+		$t->count(1, $calls);
+		$t->same('https://control.example.test/api/tenants/split-canonical/objects/reserve', $calls[0][CURLOPT_URL] ?? null);
+		$headers=is_array($calls[0][CURLOPT_HTTPHEADER] ?? null) ? $calls[0][CURLOPT_HTTPHEADER] : [];
+		$t->isTrue(in_array('X-Vestra-Control-Key: write-control-token', $headers, true));
+
+		vestra_reset_http_spy();
+		$t->isFalse(vestra_private_call('control_request', [
+			'POST',
+			$reserve_path,
+			[],
+			'split-profile',
+			'',
+			'form',
+			['write_api_token'=>null],
+		]));
+		$t->count(0, vestra_http_calls());
+	})->tag('vestra', 'credentials', 'tenant-isolation');
+
+	test('reserve uploads send canonical tenant identity while resolving the alias credential', static function(Context $t): void {
+		$file=tempnam(sys_get_temp_dir(), 'dataphyre-vestra-alias-');
+		if(!is_string($file)){
+			throw new \RuntimeException('Unable to create the Vestra reserve fixture.');
+		}
+		$contents='canonical alias upload';
+		file_put_contents($file, $contents);
+		try{
+			vestra_reset_http_spy([
+				json_encode([
+					'ok'=>true,
+					'data'=>[
+						'object_id'=>123456789,
+						'tenant'=>'split-canonical',
+						'upload'=>[
+							'url'=>'https://upload.example.test/object',
+							'method'=>'PUT',
+						],
+					],
+				], JSON_THROW_ON_ERROR|JSON_UNESCAPED_SLASHES),
+				json_encode(['ok'=>true], JSON_THROW_ON_ERROR|JSON_UNESCAPED_SLASHES),
+			]);
+			$reference=vestra_private_call('fabric_reserve_upload', [
+				$file,
+				str_repeat('a', 64),
+				'split-profile',
+				strlen($contents),
+				'text/plain',
+			]);
+			$t->type('array', $reference);
+			$t->same('split-canonical', $reference['tenant'] ?? null);
+			$t->same('split-profile', $reference['tenant_profile'] ?? null);
+
+			$calls=vestra_http_calls();
+			$t->count(2, $calls);
+			$t->same('https://control.example.test/api/tenants/split-canonical/objects/reserve', $calls[0][CURLOPT_URL] ?? null);
+			$t->same('https://upload.example.test/object', $calls[1][CURLOPT_URL] ?? null);
+			$headers=is_array($calls[0][CURLOPT_HTTPHEADER] ?? null) ? $calls[0][CURLOPT_HTTPHEADER] : [];
+			$t->isTrue(in_array('X-Vestra-Control-Key: write-control-token', $headers, true));
+			$t->isTrue(count(array_filter($headers, static fn(mixed $header): bool=>is_string($header) && str_starts_with($header, 'Idempotency-Key: dataphyre_split-canonical_')))===1);
+		}
+		finally{
+			@unlink($file);
+		}
+	})->tag('vestra', 'credentials', 'tenant-isolation');
+
+	test('write-only Control credentials can mint when access authority is explicitly denied', static function(Context $t): void {
+		vestra_without_legacy_write_token(static function() use ($t): void {
+			vestra_reset_http_spy();
+			$t->same('', vestra_private_call('vestra_api_token', ['write-only-profile']));
+			$t->same('write-only-control-token', vestra_private_call('vestra_write_api_token', ['write-only-profile']));
+			$t->same('w1.minted-test', vestra_private_call('vestra_write_token', [
+				'write-only-profile',
+				'PUT',
+				'/objects/fetch',
+				['rate'=>'s', 'max_bytes'=>64],
+			]));
+
+			$calls=vestra_http_calls();
+			$t->count(1, $calls);
+			$t->same('https://control.example.test/api/tenants/write-only-canonical/tokens/write', $calls[0][CURLOPT_URL] ?? null);
+			$headers=is_array($calls[0][CURLOPT_HTTPHEADER] ?? null) ? $calls[0][CURLOPT_HTTPHEADER] : [];
+			$t->isTrue(in_array('x-vestra-control-key: write-only-control-token', $headers, true));
+			$t->isFalse(in_array('x-vestra-control-key: flat-api-fallback', $headers, true));
+		});
+	})->tag('vestra', 'credentials', 'tenant-isolation');
+
+	test('explicit write Control denial cannot fall back to access authority', static function(Context $t): void {
+		$previous=getenv('VESTRA_WRITE_API_TOKEN');
+		putenv('VESTRA_WRITE_API_TOKEN=environment-write-control-fallback');
+		try{
+			$t->same('', vestra_private_call('vestra_write_api_token', ['write-api-denied-profile']));
+			$t->same('', vestra_private_call('control_api_token', [
+				'/tenants/write-api-denied-canonical/objects/reserve',
+				'write-api-denied-profile',
+			]));
+			$t->same('', vestra_private_call('control_api_token', [
+				'/tenants/split-canonical/objects/reserve',
+				'split-profile',
+				['write_api_token'=>null],
+			]));
+
+			vestra_without_legacy_write_token(static function() use ($t): void {
+				vestra_reset_http_spy();
+				$t->same('', vestra_private_call('vestra_write_token', [
+					'write-api-denied-profile',
+					'PUT',
+					'/objects/fetch',
+					['rate'=>'s', 'max_bytes'=>64],
+				]));
+				$t->count(0, vestra_http_calls());
+			});
+		}
+		finally{
+			$previous===false
+				? putenv('VESTRA_WRITE_API_TOKEN')
+				: putenv('VESTRA_WRITE_API_TOKEN='.$previous);
+		}
+	})->tag('vestra', 'credentials', 'tenant-isolation');
+
+	test('explicit static write-token denial still prevents Control minting', static function(Context $t): void {
+		vestra_reset_http_spy();
+		$t->same('write-control-token', vestra_private_call('vestra_write_api_token', ['write-token-denied-profile']));
+		$t->same('', vestra_private_call('vestra_write_token', [
+			'write-token-denied-profile',
+			'PUT',
+			'/objects/fetch',
+			['rate'=>'s', 'max_bytes'=>64],
+		]));
+		$t->count(0, vestra_http_calls());
+	})->tag('vestra', 'credentials', 'tenant-isolation');
+
+	test('omitted write Control credentials retain dedicated and legacy fallback order', static function(Context $t): void {
+		$t->same('flat-api-fallback', vestra_private_call('vestra_write_api_token', ['omitted-profile']));
+		$t->same('flat-api-fallback', vestra_private_call('control_api_token', [
+			'/tenants/omitted-canonical/objects/reserve',
+			'omitted-profile',
+		]));
+
+		$previous=getenv('VESTRA_WRITE_API_TOKEN');
+		putenv('VESTRA_WRITE_API_TOKEN=environment-write-control-fallback');
+		try{
+			$t->same('environment-write-control-fallback', vestra_private_call('vestra_write_api_token', ['omitted-profile']));
+		}
+		finally{
+			$previous===false
+				? putenv('VESTRA_WRITE_API_TOKEN')
+				: putenv('VESTRA_WRITE_API_TOKEN='.$previous);
+		}
+	})->tag('vestra', 'credentials', 'compatibility');
+}


### PR DESCRIPTION
## Summary
- split Vestra access-token and write/reserve Control credentials
- make explicit empty tenant credentials fail closed while preserving omitted-key compatibility
- preserve canonical tenant identity and alias-specific credential resolution across delivery, upload, and purge
- expose a versioned capability marker for downstream deployment gates

## Verification
- 10/10 credential and lifecycle cases on PHP 8.4 and PHP 8.2
- 5/5 existing Vestra contracts
- PHP lint, Composer validation, and `git diff --check`