### PR TITLE
Publish neutral runtime capability contracts

### DIFF
--- a/docs/RUNTIME_CAPABILITY_CONTRACTS.md
+++ b/docs/RUNTIME_CAPABILITY_CONTRACTS.md
@@ -1,0 +1,41 @@
+# Runtime capability contracts
+
+Dataphyre is a framework, so applications must depend on documented framework
+capabilities rather than on another application's release checks. This document
+defines the small, application-neutral runtime surfaces used by modular
+installations and by framework verification.
+
+## Why these surfaces belong in the framework
+
+| Capability | Framework responsibility | Application responsibility |
+| --- | --- | --- |
+| Table metadata | Expose a read-only normalized column-definition snapshot. | Choose tables and decide how to present or validate them. |
+| API route metadata | Carry route API metadata and bridge API dispatch through the MVC runtime. | Declare routes, authorization, and response policy. |
+| Account-isolated Stripe client | Offer an injected, per-account client boundary with local readiness and webhook verification. | Supply credentials, choose billing policy, and handle domain events. |
+| Secure scheduler claims | Validate internal provenance, one-time claims, and atomic running locks. | Register tasks and provide purpose-specific policy. |
+| Module policy | Resolve an application flight-sheet module allow/deny policy before loading modules. | Select modules for the installation. |
+
+None of these contracts names a product, tenant, catalog, receipt, or business
+workflow. They are useful to any Dataphyre application and remain optional until
+an installation enables the corresponding module or integration.
+
+## Compatibility rules
+
+Consumers must probe the documented methods and fail closed when a required
+capability is absent. Framework releases preserve the existing public facade and
+add these capability methods without requiring applications to adopt a specific
+framework consumer. Applications must not copy framework contract checks from a
+different application; the framework owns its capability documentation and
+tests.
+
+The account-isolated Stripe client never stores a secret in process-global
+configuration. The scheduler contract rejects public traffic, binds claims to a
+purpose, prevents replay, and uses an atomic lock for concurrent workers.
+
+## Verification
+
+The runtime capability contract test exercises method presence and behavior for
+the SQL, MVC/API, Stripe, and scheduler surfaces. The test uses injected fixtures
+and does not contact Stripe, mutate application databases, or require an
+application repository. Release tooling may consume the same documented
+capability list, but the framework remains the source of truth.

--- a/runtime/bootstrap.php
+++ b/runtime/bootstrap.php
@@ -5,6 +5,8 @@
  * Copyright (c) 2025 Shopiro Ltd.
  * SPDX-License-Identifier: MIT
  */
+require_once __DIR__.'/shared_request_keys.php';
+
 try{
 	bootstrap();
 }catch(\Throwable $exception){
@@ -39,6 +41,7 @@ function bootstrap(){
 	$project_root=$bootstrap_state['project_root'];
 	$bootstrap_config=$bootstrap_state['bootstrap'];
 	$bootstrap_application_roots=$bootstrap_state['application_roots'];
+	$bootstrap_module_policy=$bootstrap_state['modules'];
 	$flightdeck_replay=flightdeck_replay_request($bootstrap_config, $project_root);
 	if(($flightdeck_replay['requested'] ?? false)===true){
 		if(!isset($bootstrap_config['flightdeck']) || !is_array($bootstrap_config['flightdeck'])){
@@ -62,6 +65,7 @@ function bootstrap(){
 	define('DATAPHYRE_PROJECT_ROOT', rtrim($project_root, '/\\').'/');
 	define('DATAPHYRE_RUNTIME_ROOT', rtrim(__DIR__, '/\\').'/');
 	define('DATAPHYRE_BOOTSTRAP_CONFIG', $bootstrap_config); // still needed?
+	define('DATAPHYRE_MODULE_POLICY', $bootstrap_module_policy);
 	define('DATAPHYRE_FLIGHTDECK_CONFIG', $GLOBALS['dataphyre_flightdeck_config']);
 	define('DATAPHYRE_APPLICATION_ROOTS', $bootstrap_application_roots);
 	define('IS_PRODUCTION', $bootstrap_config['is_production'] ?? true);
@@ -152,11 +156,11 @@ function bootstrap(){
 			file_put_contents($file, bin2hex(openssl_random_pseudo_bytes(32)));
 		}
 		foreach(['_POST', '_GET', '_COOKIE'] as $source){
-			if(!empty($$source['app_override'])){
-				$key=file_get_contents($project_root.'/app_override_key');
-				$user_app=explode(',', $$source['app_override']);
-				if(($user_app[1] ?? null)===$key){
-					$bootstrap_config['app']=$user_app[0];
+			$request_source=is_array($GLOBALS[$source] ?? null) ? $GLOBALS[$source] : [];
+			if(!empty($request_source['app_override'])){
+				$application=dp_app_override_application((string)$request_source['app_override']);
+				if($application!==false){
+					$bootstrap_config['app']=$application;
 				}
 			}
 		}

--- a/runtime/bootstrap_config.php
+++ b/runtime/bootstrap_config.php
@@ -20,20 +20,21 @@ final class bootstrap_config {
 	 * Builds the effective bootstrap configuration for a runtime root.
 	 *
 	 * @param string $runtime_root Dataphyre runtime root directory.
-	 * @return array{project_root:string, bootstrap:array<string,mixed>, application_roots:array<int,string>} Effective bootstrap payload.
+	 * @return array{project_root:string, bootstrap:array<string,mixed>, application_roots:array<int,string>, modules:array{enabled:array<string,bool>,disabled:array<string,bool>,core_implicit:bool}} Effective bootstrap payload.
 	 */
 	public static function resolve(string $runtime_root): array {
 		$runtime_root=rtrim($runtime_root, '/\\').'/';
 		$install_root=rtrim(dirname($runtime_root), '/\\').'/';
 		$project_root_override=self::project_root_override();
 		$project_root=self::project_root($install_root, $project_root_override);
-		$flight_sheet=self::load_flight_sheet($install_root, $project_root_override);
+		$flight_sheet=self::load_flight_sheet($install_root, $project_root);
 		$bootstrap=array_key_exists('bootstrap', $flight_sheet) && is_array($flight_sheet['bootstrap']) ? $flight_sheet['bootstrap'] : [];
 		$config=array_replace(self::defaults($runtime_root), $bootstrap);
 		return [
 			'project_root'=>$project_root,
 			'bootstrap'=>$config,
 			'application_roots'=>self::normalize_application_roots($project_root, (array)($config['application_roots'] ?? [])),
+			'modules'=>self::normalize_modules($config['modules'] ?? []),
 		];
 	}
 
@@ -59,6 +60,10 @@ final class bootstrap_config {
 			'public_ip_address'=>null,
 			'web_server_port'=>null,
 			'license'=>false,
+			'modules'=>[
+				'enabled'=>[],
+				'disabled'=>[],
+			],
 			'flightdeck'=>[
 				'enabled'=>true,
 				'password'=>null,
@@ -81,9 +86,10 @@ final class bootstrap_config {
 	/**
 	 * Resolves the application project root for standalone and embedded installs.
 	 *
-	 * Embedded layouts keep Dataphyre under `common/dataphyre`; standalone package
-	 * installs keep `runtime/`, `flight_sheet.php`, and app roots beside each
-	 * other in the install root.
+	 * Canonical embedded layouts keep Dataphyre under `<project>/dataphyre` and
+	 * keep the live flight sheet in the project root. Standalone package installs
+	 * keep `runtime/`, `flight_sheet.php`, and app roots together. The former
+	 * `<project>/common/dataphyre` layout remains a resolution-only fallback.
 	 *
 	 * @param string $install_root Dataphyre install root.
 	 * @param string|null $project_root_override Explicit project root for vendor installs.
@@ -98,6 +104,16 @@ final class bootstrap_config {
 		if(strtolower(basename($install_root))==='dataphyre' && strtolower(basename($parent))==='common'){
 			return rtrim(dirname($parent), '/\\').'/';
 		}
+		if(
+			strtolower(basename($install_root))==='dataphyre'
+			&& (
+				is_file($parent.'/flight_sheet.php')
+				|| is_file($parent.'/dataphyre.project.json')
+				|| is_dir($parent.'/applications')
+			)
+		){
+			return rtrim($parent, '/\\').'/';
+		}
 		return $install_root.'/';
 	}
 
@@ -105,14 +121,60 @@ final class bootstrap_config {
 	 * Loads the install-level or explicit project-root flight sheet when present.
 	 *
 	 * @param string $install_root Dataphyre install root.
-	 * @param string|null $project_root_override Explicit project root for vendor installs.
+	 * @param string $project_root Resolved project root.
 	 * @return array<string,mixed> Flight sheet payload, or an empty array when absent or invalid.
 	 */
-	private static function load_flight_sheet(string $install_root, ?string $project_root_override): array {
-		$flight_sheet_root=$project_root_override ?? $install_root;
-		$flight_sheet_path=$flight_sheet_root.'flight_sheet.php';
+	private static function load_flight_sheet(string $install_root, string $project_root): array {
+		$project_sheet=rtrim($project_root, '/\\').'/flight_sheet.php';
+		$install_sheet=rtrim($install_root, '/\\').'/flight_sheet.php';
+		$flight_sheet_path=is_file($project_sheet) ? $project_sheet : $install_sheet;
 		$flight_sheet=is_file($flight_sheet_path) ? require($flight_sheet_path) : [];
 		return is_array($flight_sheet) ? $flight_sheet : [];
+	}
+
+	/**
+	 * Normalizes the selected flight sheet's module policy into lookup sets.
+	 *
+	 * The enabled list is authoritative, disabled entries remove matching enabled
+	 * entries, and names are normalized once during bootstrap. Core is a reserved
+	 * bootstrap dependency and remains implicitly enabled outside application
+	 * module selection.
+	 *
+	 * @param mixed $modules Raw `bootstrap.modules` payload.
+	 * @return array{enabled:array<string,bool>,disabled:array<string,bool>,core_implicit:bool} Normalized module policy.
+	 */
+	private static function normalize_modules(mixed $modules): array {
+		$modules=is_array($modules) ? $modules : [];
+		$enabled=self::normalize_module_set(is_array($modules['enabled'] ?? null) ? $modules['enabled'] : []);
+		$disabled=self::normalize_module_set(is_array($modules['disabled'] ?? null) ? $modules['disabled'] : []);
+		foreach($disabled as $module=>$_){
+			unset($enabled[$module]);
+		}
+		unset($disabled['core']);
+		$enabled=['core'=>true]+$enabled;
+		return [
+			'enabled'=>$enabled,
+			'disabled'=>$disabled,
+			'core_implicit'=>true,
+		];
+	}
+
+	/**
+	 * Converts a raw module list into an associative membership set.
+	 *
+	 * @param array<int,mixed> $modules Raw module names.
+	 * @return array<string,bool> Normalized module-name set.
+	 */
+	private static function normalize_module_set(array $modules): array {
+		$set=[];
+		foreach($modules as $module){
+			$module=strtolower(trim((string)$module));
+			if($module==='' || preg_match('/^[a-z0-9][a-z0-9_-]*$/', $module)!==1){
+				continue;
+			}
+			$set[$module]=true;
+		}
+		return $set;
 	}
 
 	/**

--- a/runtime/modules/api/Framework/ApiManager.php
+++ b/runtime/modules/api/Framework/ApiManager.php
@@ -7,6 +7,20 @@
  */
 namespace Dataphyre\Api;
 
+if(!function_exists(__NAMESPACE__.'\\tracelog')){
+	function tracelog(...$arguments): void {
+		if(\function_exists('tracelog')){
+			\tracelog(...$arguments);
+		}
+	}
+}
+
+if(!function_exists(__NAMESPACE__.'\\api_dialback')){
+	function api_dialback(string $event, mixed ...$arguments): mixed {
+		return \dataphyre\core::dialback($event, ...$arguments);
+	}
+}
+
 use Dataphyre\Http\Request;
 use Dataphyre\Http\Response;
 use Dataphyre\Routing\ControllerAction;
@@ -678,9 +692,6 @@ final class ApiManager {
 			(string)($route['path_template'] ?? $route['exact_path'] ?? ($route['api']['path'] ?? '/')),
 			$routeParameters
 		);
-		if($resolvedPath===null){
-			return ['status'=>422, 'message'=>'API alias dispatch could not build a route path.'];
-		}
 
 		$route['parameters']=$routeParameters;
 		$definition['path']=$resolvedPath;
@@ -719,17 +730,7 @@ final class ApiManager {
 		if(($options['trust_auth'] ?? false)===true && is_array($options['auth'] ?? null)){
 			$attributes[self::AUTH_ATTRIBUTE]=$options['auth'];
 		}
-		return Request::create(
-			$definition['method'],
-			$definition['path'],
-			$definition['query'],
-			$definition['body'],
-			$cookies,
-			$server,
-			$headers,
-			$route['parameters'] ?? [],
-			$attributes
-		);
+		return Request::create($definition['method'], $definition['path'], $definition['query'], $definition['body'], $cookies, $server, $headers, $route['parameters'] ?? [], $attributes);
 	}
 
 	/**
@@ -889,7 +890,7 @@ final class ApiManager {
 	private function resolveAliasRouteParameters(array $route, array $definition): ?array {
 		$routeParameters=is_array($definition['route_parameters'] ?? null) ? $definition['route_parameters'] : [];
 		$pathTemplate=(string)($route['path_template'] ?? $route['exact_path'] ?? ($route['api']['path'] ?? '/'));
-		if(preg_match_all('/\{([A-Za-z_][A-Za-z0-9_]*)\}/', $pathTemplate, $matches)!==1){
+		if(preg_match_all('/\{([A-Za-z_][A-Za-z0-9_]*)\}/', $pathTemplate, $matches)<1){
 			return $routeParameters;
 		}
 		foreach($matches[1] as $parameterName){
@@ -918,7 +919,7 @@ final class ApiManager {
 	 */
 	private function interpolateRoutePathTemplate(string $pathTemplate, array $parameters): ?string {
 		$pathTemplate=self::normalizePath($pathTemplate);
-		if(preg_match_all('/\{([A-Za-z_][A-Za-z0-9_]*)\}/', $pathTemplate, $matches)!==1){
+		if(preg_match_all('/\{([A-Za-z_][A-Za-z0-9_]*)\}/', $pathTemplate, $matches)<1){
 			return $pathTemplate;
 		}
 		foreach($matches[1] as $parameterName){
@@ -1032,9 +1033,7 @@ final class ApiManager {
 			return;
 		}
 		if($bootstrap==='core'){
-			if(defined('DP_CORE_LOADED')===false){
-				require_once(ROOTPATH['common_dataphyre_runtime'].'modules/core/kernel/core.main.php');
-			}
+			$this->loadFrameworkModule('core');
 			return;
 		}
 		if(is_string($bootstrap) && is_file($bootstrap)){
@@ -1320,7 +1319,7 @@ final class ApiManager {
 			'route'=>$this->apiRouteTraceDescriptor($route),
 			'extra_count'=>count($extra),
 		];
-		$dialback=\dataphyre\core::dialback('CALL_API_FRAMEWORK_LIFECYCLE_BEFORE_RUN', $payload);
+		$dialback=api_dialback('CALL_API_FRAMEWORK_LIFECYCLE_BEFORE_RUN', $payload);
 		if($dialback instanceof Response){
 			tracelog(__FILE__, __LINE__, __CLASS__, __FUNCTION__, $T='API lifecycle phase short-circuited before run; phase='.$phase.'; route='.$this->apiRouteTraceLabel($route).'; hooks='.count($hooks).'; status='.$dialback->status, $S=$dialback->status < 400 ? 'info' : 'warning');
 			return $dialback;
@@ -1332,7 +1331,7 @@ final class ApiManager {
 			$result=$this->invokeLifecycleHook($phase, $hook, $context, $request, $route, ...$extra);
 			if($result instanceof Response){
 				tracelog(__FILE__, __LINE__, __CLASS__, __FUNCTION__, $T='API lifecycle phase short-circuited by hook; phase='.$phase.'; route='.$this->apiRouteTraceLabel($route).'; hooks='.count($hooks).'; status='.$result->status, $S=$result->status < 400 ? 'info' : 'warning');
-				$dialback=\dataphyre\core::dialback('CALL_API_FRAMEWORK_LIFECYCLE_AFTER_RUN', $payload+['short_circuited'=>true, 'status'=>$result->status]);
+				$dialback=api_dialback('CALL_API_FRAMEWORK_LIFECYCLE_AFTER_RUN', $payload+['short_circuited'=>true, 'status'=>$result->status]);
 				if($dialback instanceof Response){
 					return $dialback;
 				}
@@ -1340,7 +1339,7 @@ final class ApiManager {
 			}
 		}
 		tracelog(__FILE__, __LINE__, __CLASS__, __FUNCTION__, $T='API lifecycle phase completed; phase='.$phase.'; route='.$this->apiRouteTraceLabel($route).'; hooks='.count($hooks), $S='info');
-		$dialback=\dataphyre\core::dialback('CALL_API_FRAMEWORK_LIFECYCLE_AFTER_RUN', $payload+['short_circuited'=>false]);
+		$dialback=api_dialback('CALL_API_FRAMEWORK_LIFECYCLE_AFTER_RUN', $payload+['short_circuited'=>false]);
 		if($dialback instanceof Response){
 			return $dialback;
 		}
@@ -1381,7 +1380,7 @@ final class ApiManager {
 			'reference'=>isset($hook['reference']) && is_string($hook['reference']) ? trim($hook['reference']) : null,
 			'extra_count'=>count($extra),
 		];
-		$dialback=\dataphyre\core::dialback('CALL_API_FRAMEWORK_LIFECYCLE_BEFORE_INVOKE', $payload);
+		$dialback=api_dialback('CALL_API_FRAMEWORK_LIFECYCLE_BEFORE_INVOKE', $payload);
 		if($dialback instanceof Response){
 			tracelog(__FILE__, __LINE__, __CLASS__, __FUNCTION__, $T='API lifecycle hook replaced before invoke; phase='.$phase.'; route='.$this->apiRouteTraceLabel($route).'; status='.$dialback->status, $S=$dialback->status < 400 ? 'info' : 'warning');
 			return $dialback;
@@ -1393,7 +1392,7 @@ final class ApiManager {
 		};
 		$result=$this->invokeCallableWithArgs($callable, $args);
 		tracelog(__FILE__, __LINE__, __CLASS__, __FUNCTION__, $T='API lifecycle hook invoked; phase='.$phase.'; route='.$this->apiRouteTraceLabel($route).'; result_type='.$this->apiValueType($result), $S=$result instanceof Response && $result->status >= 400 ? 'warning' : 'info');
-		$dialback=\dataphyre\core::dialback('CALL_API_FRAMEWORK_LIFECYCLE_AFTER_INVOKE', $payload+[
+		$dialback=api_dialback('CALL_API_FRAMEWORK_LIFECYCLE_AFTER_INVOKE', $payload+[
 			'result_type'=>$this->apiValueType($result),
 			'status'=>$result instanceof Response ? $result->status : null,
 		]);
@@ -1422,9 +1421,11 @@ final class ApiManager {
 				if(class_exists($class)===false){
 					return null;
 				}
-				return [new $class(), $method];
+				$callable=[new $class(), $method];
+				return is_callable($callable) ? $callable : null;
 			}
-			return [$class, $method];
+			$callable=[$class, $method];
+			return is_callable($callable) ? $callable : null;
 		}
 		if($type==='callable'){
 			$reference=trim((string)($execution['reference'] ?? ''));
@@ -1699,20 +1700,11 @@ final class ApiManager {
 			}
 			$bindingContext=$this->bindingContextForApi($context, [], $path, $traceContext, ++$bindingSequence);
 			$binding=$this->bindingFromDefinition($path, $definition);
-			$metadata=$binding instanceof \Dataphyre\Templating\BindingMetadataProvider
-				? $binding->metadata()
-				: [];
+			$metadata=$binding->metadata();
 			$bindingQueryCacheNames=array_merge(
 				$bindingQueryCacheNames,
 				$this->normalizeEndpointCacheNames($metadata['query_cache_names'] ?? [])
 			);
-			if(!$binding instanceof \Dataphyre\Templating\BindingCacheIdentityProvider){
-				if($allowUntrackedBindings!==true){
-					$bindingReason="Binding '{$path}' does not expose cache identity.";
-					break;
-				}
-				continue;
-			}
 			$identity=$this->normalizeBindingCacheIdentity($binding->cacheIdentity($bindingContext));
 			if($identity===null){
 				if($allowUntrackedBindings!==true){
@@ -1760,20 +1752,6 @@ final class ApiManager {
 			'bindings'=>$bindingIdentities!==[] ? $bindingIdentities : null,
 			'identity'=>$extraIdentity,
 		], static fn(mixed $value): bool => $value!==null && $value!==[]);
-
-		if($identity===[]){
-			return [
-				'enabled'=>true,
-				'cacheable'=>false,
-				'state'=>'bypass',
-				'layer'=>'none',
-				'reason'=>'Endpoint cache identity is empty.',
-				'names'=>$this->normalizeEndpointCacheNames(array_merge(
-					$this->normalizeEndpointCacheNames($cacheDefinition['names'] ?? []),
-					$bindingQueryCacheNames
-				)),
-			];
-		}
 
 		$names=$this->normalizeEndpointCacheNames(array_merge(
 			$this->normalizeEndpointCacheNames($cacheDefinition['names'] ?? []),
@@ -2171,7 +2149,9 @@ final class ApiManager {
 		$selected=[];
 		foreach($names as $name){
 			foreach($source as $sourceName=>$value){
-				if(strtolower((string)$sourceName)!==strtolower($name)){
+				$normalizedSourceName=str_replace('-', '_', strtolower((string)$sourceName));
+				$normalizedName=str_replace('-', '_', strtolower($name));
+				if($normalizedSourceName!==$normalizedName){
 					continue;
 				}
 				$selected[$name]=$value;
@@ -2231,7 +2211,10 @@ final class ApiManager {
 	 * @return string Absolute cache root ending with a directory separator.
 	 */
 	private function endpointCacheRoot(): string {
-		return rtrim(ROOTPATH['dataphyre'].'cache/api/endpoints/', '/\\').DIRECTORY_SEPARATOR;
+		$cacheRoot=is_string(ROOTPATH['api_cache'] ?? null) && trim((string)ROOTPATH['api_cache'])!==''
+			? rtrim((string)ROOTPATH['api_cache'], '/\\')
+			: rtrim((string)ROOTPATH['dataphyre'], '/\\').DIRECTORY_SEPARATOR.'cache'.DIRECTORY_SEPARATOR.'api';
+		return $cacheRoot.DIRECTORY_SEPARATOR.'endpoints'.DIRECTORY_SEPARATOR;
 	}
 
 	/**
@@ -2348,9 +2331,7 @@ final class ApiManager {
 			return;
 		}
 		if($bootstrap==='core'){
-			if(defined('DP_CORE_LOADED')===false){
-				require_once(ROOTPATH['common_dataphyre_runtime'].'modules/core/kernel/core.main.php');
-			}
+			$this->loadFrameworkModule('core');
 			return;
 		}
 		if(is_string($bootstrap) && is_file($bootstrap)){
@@ -2435,12 +2416,8 @@ final class ApiManager {
 
 			$bindingContext=$this->bindingContextForApi($context, $resolved, $path, $traceContext, ++$sequence);
 			$binding=$this->bindingFromDefinition($path, $definition);
-			$metadata=$binding instanceof \Dataphyre\Templating\BindingMetadataProvider
-				? $binding->metadata()
-				: [];
-			$identity=$binding instanceof \Dataphyre\Templating\BindingCacheIdentityProvider
-				? $this->normalizeBindingCacheIdentity($binding->cacheIdentity($bindingContext))
-				: null;
+			$metadata=$binding->metadata();
+			$identity=$this->normalizeBindingCacheIdentity($binding->cacheIdentity($bindingContext));
 			$cacheKey=$identity!==null ? sha1(json_encode($identity)) : null;
 			$startedAt=microtime(true);
 			$reused=false;
@@ -2485,11 +2462,11 @@ final class ApiManager {
 	 *
 	 * @param string $path Binding destination path in the API context.
 	 * @param array{type?:string} $definition Compiled binding definition.
-	 * @return \Dataphyre\Templating\DataBinding Runtime binding instance.
+	 * @return \Dataphyre\Templating\DataBinding&\Dataphyre\Templating\BindingMetadataProvider&\Dataphyre\Templating\BindingCacheIdentityProvider Runtime binding instance.
 	 *
 	 * @throws \RuntimeException When the binding type is unsupported.
 	 */
-	private function bindingFromDefinition(string $path, array $definition): \Dataphyre\Templating\DataBinding {
+	private function bindingFromDefinition(string $path, array $definition): \Dataphyre\Templating\DataBinding&\Dataphyre\Templating\BindingMetadataProvider&\Dataphyre\Templating\BindingCacheIdentityProvider {
 		$type=strtolower(trim((string)($definition['type'] ?? '')));
 		return match ($type) {
 			'callable' => $this->callableBindingFromDefinition($path, $definition),
@@ -2890,7 +2867,7 @@ final class ApiManager {
 		foreach($segments as $index=>$segment){
 			if($index===count($segments)-1){
 				$current[$segment]=$value;
-				return;
+				break;
 			}
 			if(!isset($current[$segment]) || !is_array($current[$segment])){
 				$current[$segment]=[];
@@ -3188,7 +3165,7 @@ final class ApiManager {
 			'scope_count'=>count($scopes),
 			'runtime_keys'=>array_values(array_map('strval', array_keys($runtime))),
 		];
-		$dialback=\dataphyre\core::dialback('CALL_API_FRAMEWORK_AUTH_BEFORE_RESOLVER', $payload);
+		$dialback=api_dialback('CALL_API_FRAMEWORK_AUTH_BEFORE_RESOLVER', $payload);
 		if($dialback!==null){
 			$result=$this->normalizeAuthorizationResult($schemeName, $runtime, $dialback);
 			tracelog(__FILE__, __LINE__, __CLASS__, __FUNCTION__, $T='API auth resolver replaced before invoke; route='.$this->apiRouteTraceLabel($route).'; scheme='.$schemeName.'; authorized='.(($result['authorized'] ?? false)===true ? 'yes' : 'no'), $S=($result['authorized'] ?? false)===true ? 'info' : 'warning');
@@ -3197,7 +3174,7 @@ final class ApiManager {
 		$result=$resolver($credentials, $request, $route, $scopes, $runtime);
 		$normalized=$this->normalizeAuthorizationResult($schemeName, $runtime, $result);
 		tracelog(__FILE__, __LINE__, __CLASS__, __FUNCTION__, $T='API auth resolver completed; route='.$this->apiRouteTraceLabel($route).'; scheme='.$schemeName.'; authorized='.(($normalized['authorized'] ?? false)===true ? 'yes' : 'no').'; result_type='.$this->apiValueType($result), $S=($normalized['authorized'] ?? false)===true ? 'info' : 'warning');
-		$dialback=\dataphyre\core::dialback('CALL_API_FRAMEWORK_AUTH_AFTER_RESOLVER', $payload+[
+		$dialback=api_dialback('CALL_API_FRAMEWORK_AUTH_AFTER_RESOLVER', $payload+[
 			'authorized'=>($normalized['authorized'] ?? false)===true,
 			'status'=>$normalized['status'] ?? null,
 			'result_type'=>$this->apiValueType($result),
@@ -3364,18 +3341,32 @@ final class ApiManager {
 		if($definition===null){
 			return ['version'=>1, 'metadata'=>[], 'routes'=>[]];
 		}
-		if(!empty($definition->compiledRoutesFile) && is_file($definition->compiledRoutesFile)){
-			$manifest=require($definition->compiledRoutesFile);
+		if(!empty($definition->compiled_routes_file) && is_file($definition->compiled_routes_file)){
+			$manifest=require($definition->compiled_routes_file);
 			return is_array($manifest) ? $manifest : ['version'=>1, 'metadata'=>[], 'routes'=>[]];
 		}
-		if(!empty($definition->routesFile) && is_file($definition->routesFile)){
+		if(!empty($definition->routes_file) && is_file($definition->routes_file)){
 			if(class_exists('\dataphyre\core', false)){
 				\dataphyre\core::load_framework_module('routing');
 			}
-			return \Dataphyre\Routing\RouteCompiler::compileFile($definition->routesFile, [
+			return \Dataphyre\Routing\RouteCompiler::compileFile($definition->routes_file, [
 				'application'=>$definition->id,
 				'compiled_at'=>gmdate('c'),
 			]);
+		}
+		if(class_exists('\Dataphyre\Mvc\Mvc', false)){
+			try{
+				$manifest=\Dataphyre\Mvc\Mvc::routes($definition->id)->compile([
+					'application'=>$definition->id,
+					'compiled_at'=>gmdate('c'),
+					'source'=>'dataphyre.mvc.api',
+				]);
+				if(is_array($manifest) && is_array($manifest['routes'] ?? null) && $manifest['routes']!==[]){
+					return $manifest;
+				}
+			}catch(\Throwable){
+				// The MVC app may not be registered in CLI-only API discovery contexts.
+			}
 		}
 		return ['version'=>1, 'metadata'=>['application'=>$definition->id], 'routes'=>[]];
 	}
@@ -3416,19 +3407,14 @@ final class ApiManager {
 	 * @return ?string Absolute project root without a trailing separator.
 	 */
 	private function projectRoot(): ?string {
-		if(class_exists('Dataphyre\\Runtime')){
-			$projectRoot=\Dataphyre\Runtime::projectRoot();
-			if(is_string($projectRoot) && trim($projectRoot)!==''){
-				return rtrim($projectRoot, '/\\');
-			}
-		}
 		if(class_exists('\dataphyre\runtime', false)){
 			$projectRoot=\dataphyre\runtime::current_project_root();
 			if(is_string($projectRoot) && trim($projectRoot)!==''){
 				return rtrim($projectRoot, '/\\');
 			}
 		}
-		return null;
+		$projectRoot=defined('ROOTPATH') && is_array(ROOTPATH) ? (ROOTPATH['root'] ?? null) : null;
+		return is_string($projectRoot) && trim($projectRoot)!=='' ? rtrim($projectRoot, '/\\') : null;
 	}
 
 	/**

--- a/runtime/modules/core/Framework/Runtime.php
+++ b/runtime/modules/core/Framework/Runtime.php
@@ -8,12 +8,14 @@
 namespace Dataphyre;
 
 /**
- * Static facade for current Dataphyre runtime state, catalogs, bootstrap plans, client address, and render traces.
+ * Framework-facing methods composed into the canonical Dataphyre runtime class.
  *
- * Runtime keeps framework callers away from lower-case kernel classes while preserving the same
- * discovery order for project roots, applications, modules, bootstraps, and optional SQL/template trace data.
+ * PHP class names are case-insensitive, so `Dataphyre\Runtime` and the legacy
+ * `dataphyre\runtime` spelling necessarily identify one class. The kernel runtime
+ * composes this trait so both spellings expose the same discovery, catalog, state,
+ * bootstrap, client-address, and render-trace APIs without declaring a duplicate class.
  */
-final class Runtime {
+trait RuntimeFrameworkSurface {
 
 	/**
 	 * Reports whether diagnostic tracing is enabled for the current runtime.
@@ -333,4 +335,11 @@ final class Runtime {
 		}
 		return null;
 	}
+}
+
+// Loading the Framework surface first must still materialize the canonical
+// runtime class. When kernel/runtime.php initiated this include, require_once
+// safely recognizes the in-progress kernel file and lets that declaration resume.
+if(!class_exists('dataphyre\\runtime', false)){
+	require_once dirname(__DIR__).'/kernel/runtime.php';
 }

--- a/runtime/modules/core/kernel/autoloader.php
+++ b/runtime/modules/core/kernel/autoloader.php
@@ -102,7 +102,7 @@ final class autoloader {
 	}
 
 	/**
-	 * Discovers and registers kernel prefixes for every module below a runtime modules root.
+	 * Registers kernel prefixes only for flight-sheet-enabled module names.
 	 *
 	 * @param string $modules_root Runtime modules directory.
 	 * @return void
@@ -111,8 +111,13 @@ final class autoloader {
 		if(isset(self::$registered_module_roots[$modules_root])){
 			return;
 		}
+		require_once(__DIR__.'/module_registry.php');
 		$prefixes=[];
-		foreach(glob($modules_root.'/*', GLOB_ONLYDIR) ?: [] as $module_directory){
+		foreach(\dataphyre\module_registry::enabled_modules() as $module){
+			$module_directory=$modules_root.'/'.$module;
+			if(!is_dir($module_directory)){
+				continue;
+			}
 			$prefixes=array_merge($prefixes, self::kernel_prefixes($module_directory));
 		}
 		self::register_prefixes($prefixes);
@@ -129,11 +134,12 @@ final class autoloader {
 	 * @return array<int, string> Unique module names whose Framework prefixes were registered.
 	 */
 	public static function register_framework_modules(array|string $modules): array {
+		require_once(__DIR__.'/module_registry.php');
 		$modules=is_array($modules) ? $modules : [$modules];
 		$loaded=[];
 		foreach($modules as $module){
 			$module=strtolower(trim((string)$module));
-			if($module===''){
+			if($module==='' || \dataphyre\module_registry::module_enabled($module)===false){
 				continue;
 			}
 			$prefixes=self::framework_prefixes_for_module($module);
@@ -153,7 +159,9 @@ final class autoloader {
 	 * @return bool `true` when at least one registered module root contains a Framework directory for the module.
 	 */
 	public static function framework_module_available(string $module): bool {
-		return self::framework_prefixes_for_module($module)!==[];
+		require_once(__DIR__.'/module_registry.php');
+		return \dataphyre\module_registry::module_enabled($module)
+			&& self::framework_prefixes_for_module($module)!==[];
 	}
 
 	/**
@@ -163,6 +171,10 @@ final class autoloader {
 	 * @return array<string, string> Namespace prefix to Framework directory map.
 	 */
 	private static function framework_prefixes_for_module(string $module): array {
+		require_once(__DIR__.'/module_registry.php');
+		if(\dataphyre\module_registry::module_enabled($module)===false){
+			return [];
+		}
 		$prefixes=[];
 		foreach(array_keys(self::$registered_module_roots) as $modules_root){
 			$module_directory=rtrim($modules_root, '/\\').'/'.$module;

--- a/runtime/modules/core/kernel/module_registry.php
+++ b/runtime/modules/core/kernel/module_registry.php
@@ -8,9 +8,11 @@
 namespace dataphyre;
 
 /**
- * Discovers Dataphyre runtime modules and resolves their kernel and framework entrypoints.
+ * Resolves flight-sheet-enabled Dataphyre modules and their entrypoints.
  *
- * The registry scans common and application module directories, merges application overrides over shared definitions, applies configured enabled/disabled lists, and caches normalized definitions for bootstrap callers. Disabled application shadow directories prefixed with "-" suppress shared modules without adding compatibility layers.
+ * The selected application's normalized flight-sheet policy is the sole source
+ * of module enablement. Filesystem inspection happens only after a constant-time
+ * policy lookup permits a module; directories never opt themselves into boot.
  */
 final class module_registry {
 
@@ -55,81 +57,54 @@ final class module_registry {
 	}
 
 	/**
-	 * Lists module directory names discoverable from common and application roots.
+	 * Lists enabled modules that resolve to a usable on-disk definition.
 	 *
-	 * Availability is filesystem-based and does not imply that a module is enabled or has a usable entrypoint. Application and common roots are unioned, dash-prefixed directories are ignored, names are normalized to lowercase, and the result is sorted for deterministic bootstrap order.
+	 * This explicit catalog operation inspects only names already allowed by the
+	 * flight sheet. It never scans module directories for candidates.
 	 *
-	 * @return array<int,string> Sorted normalized module names discovered on disk.
+	 * @return array<int,string> Resolvable module names in flight-sheet order.
 	 */
 	public static function available_modules(): array {
 		if(self::$available_modules_cache!==null){
 			return self::$available_modules_cache;
 		}
-		if(defined('ROOTPATH')===false){
-			return self::$available_modules_cache=[];
-		}
-		$modules=[];
-		foreach([
-			ROOTPATH['common_dataphyre_runtime'].'modules/',
-			ROOTPATH['dataphyre'].'modules/',
-		] as $modules_root){
-			if(!is_dir($modules_root)){
-				continue;
-			}
-			foreach(scandir($modules_root) ?: [] as $entry){
-				if($entry==='.' || $entry==='..'){
-					continue;
-				}
-				$entry=self::normalize_module_name($entry);
-				if($entry==='' || $entry[0]==='-'){
-					continue;
-				}
-				if(!is_dir(rtrim($modules_root, '/\\').'/'.$entry)){
-					continue;
-				}
-				$modules[$entry]=true;
+		$available=[];
+		foreach(self::enabled_modules() as $module){
+			if(self::module_definition($module)!==false){
+				$available[]=$module;
 			}
 		}
-		$names=array_keys($modules);
-		sort($names);
-		return self::$available_modules_cache=$names;
+		return self::$available_modules_cache=$available;
 	}
 
 	/**
-	 * Lists available modules whose resolved definition is enabled.
+	 * Lists module names enabled by the selected application's flight sheet.
 	 *
-	 * Enabled state is derived from module configuration, disabled application shadow directories, and successful definition inspection. Returned names follow available_modules() ordering.
+	 * This is a constant-time read after bootstrap normalization and does not
+	 * inspect the filesystem. An enabled name may still fail to resolve if the
+	 * package is missing, in which case presence/load methods return false.
 	 *
 	 * @return array<int,string> Enabled module names.
 	 */
 	public static function enabled_modules(): array {
-		$enabled=[];
-		foreach(self::available_modules() as $module){
-			$definition=self::module_definition($module);
-			if(is_array($definition) && ($definition['enabled'] ?? false)===true){
-				$enabled[]=$module;
-			}
-		}
-		return $enabled;
+		return array_keys(self::module_config()['enabled']);
 	}
 
 	/**
-	 * Lists modules with valid definitions that are currently disabled.
+	 * Lists module names explicitly disabled by the selected flight sheet.
 	 *
-	 * This reports modules that can be inspected but fail the enabled-state filter. Missing or structurally invalid module directories are not included because no definition can be built for them.
+	 * The result is policy-derived and does not inspect disabled module paths.
 	 *
-	 * @return array<int,string> Sorted disabled module names.
+	 * @return array<int,string> Disabled module names in flight-sheet order.
 	 */
 	public static function disabled_modules(): array {
-		$disabled=array_keys(self::module_definitions(false));
-		sort($disabled);
-		return $disabled;
+		return array_keys(self::module_config()['disabled']);
 	}
 
 	/**
-	 * Checks whether one module resolves to an enabled definition.
+	 * Checks whether one module is allowed by the normalized flight-sheet policy.
 	 *
-	 * Blank names are rejected after normalization. A true return means the module has at least one valid kernel or framework surface and is not filtered by enabled/disabled configuration.
+	 * This hot path is an associative lookup and never touches the filesystem.
 	 *
 	 * @param string $module Module name to normalize and inspect.
 	 * @return bool True when the module is known and enabled.
@@ -139,8 +114,8 @@ final class module_registry {
 		if($module===''){
 			return false;
 		}
-		$definition=self::module_definition($module);
-		return is_array($definition) && ($definition['enabled'] ?? false)===true;
+		$config=self::module_config();
+		return isset($config['enabled'][$module]) && !isset($config['disabled'][$module]);
 	}
 
 	/**
@@ -171,7 +146,9 @@ final class module_registry {
 	/**
 	 * Builds the full resolved definition for one module.
 	 *
-	 * Shared runtime modules provide the base definition; application modules can replace kernel or framework entrypoints and record their own directory. A valid definition must expose at least a kernel entry, a framework bootstrap, or a framework directory. The final enabled flag combines configuration allow/deny lists with application dash-directory suppression.
+	 * Shared runtime modules provide the base definition; application modules can
+	 * replace kernel or framework entrypoints and record their own directory. A
+	 * policy denial returns before any path is inspected.
 	 *
 	 * @param string $module Module name to normalize and inspect.
 	 * @return array<string,mixed>|false Resolved definition with directory and entrypoint metadata, or false when invalid.
@@ -184,11 +161,13 @@ final class module_registry {
 		if(array_key_exists($module, self::$definition_cache)){
 			return self::$definition_cache[$module];
 		}
-		if(defined('ROOTPATH')===false){
+		if(self::module_enabled($module)===false || defined('ROOTPATH')===false){
 			return self::$definition_cache[$module]=false;
 		}
-		$common=self::inspect_module_directory(ROOTPATH['common_dataphyre_runtime'].'modules/'.$module.'/', $module);
-		$app=self::inspect_module_directory(ROOTPATH['dataphyre'].'modules/'.$module.'/', $module);
+		$common_root=rtrim((string)(ROOTPATH['common_dataphyre_runtime'] ?? ''), '/\\');
+		$app_root=rtrim((string)(ROOTPATH['dataphyre'] ?? ''), '/\\');
+		$common=$common_root!=='' ? self::inspect_module_directory($common_root.'/modules/'.$module.'/', $module) : null;
+		$app=$app_root!=='' ? self::inspect_module_directory($app_root.'/modules/'.$module.'/', $module) : null;
 		if($common!==null){
 			$common['common_directory']=$common['directory'];
 		}
@@ -227,33 +206,31 @@ final class module_registry {
 				$definition['directory']=$app['directory'];
 			}
 		}
-		if(
-			($definition['kernel_entry'] ?? null)===null
-			&& ($definition['framework_entry'] ?? null)===null
-			&& ($definition['framework_directory'] ?? null)===null
-		){
-			return self::$definition_cache[$module]=false;
-		}
-		$definition['enabled']=self::is_enabled($module) && self::is_app_disabled($module)===false;
+		// inspect_module_directory() returns a definition only when at least one
+		// kernel or Framework surface exists. The common/app merge above preserves
+		// every discovered surface, so a second no-surface guard here was dead code.
+		$definition['enabled']=true;
 		return self::$definition_cache[$module]=$definition;
 	}
 
 	/**
 	 * Returns resolved module definitions, optionally filtered by enabled state.
 	 *
-	 * Definitions are keyed by normalized module name. Invalid module directories are skipped, and the optional filter compares against the resolved enabled flag after configuration and app-level suppression have been applied.
+	 * Definitions are keyed by normalized module name and are resolved only for
+	 * enabled names. A disabled filter therefore returns an empty catalog; use
+	 * disabled_modules() to inspect the explicit deny set without touching disk.
 	 *
 	 * @param ?bool $enabled Null for all valid definitions, true for enabled only, false for disabled only.
 	 * @return array<string,array<string,mixed>> Definitions keyed by module name.
 	 */
 	public static function module_definitions(?bool $enabled=null): array {
+		if($enabled===false){
+			return [];
+		}
 		$definitions=[];
-		foreach(self::available_modules() as $module){
+		foreach(self::enabled_modules() as $module){
 			$definition=self::module_definition($module);
 			if(!is_array($definition)){
-				continue;
-			}
-			if($enabled!==null && (($definition['enabled'] ?? false)===true)!==$enabled){
 				continue;
 			}
 			$definitions[$module]=$definition;
@@ -262,99 +239,39 @@ final class module_registry {
 	}
 
 	/**
-	 * Loads and merges module enablement configuration from all supported sources.
+	 * Returns the selected application's normalized flight-sheet module policy.
 	 *
-	 * Configuration may be a simple list of enabled modules or an associative payload with enabled and disabled keys. Later sources override the enabled allow-list, while disabled lists accumulate across sources.
+	 * `DATAPHYRE_MODULE_POLICY` is produced once by bootstrap_config. The raw
+	 * bootstrap constant is accepted only as a bootstrap-safe fallback for tools
+	 * that load this class directly. Legacy config/modules.php and APP_MODULES
+	 * are intentionally not consulted.
 	 *
-	 * @return array{enabled:?array<int,string>,disabled:array<int,string>} Normalized module configuration.
+	 * @return array{enabled:array<string,bool>,disabled:array<string,bool>} Module lookup sets.
 	 */
 	private static function module_config(): array {
 		if(self::$module_config!==null){
 			return self::$module_config;
 		}
-		$config=[
-			'enabled'=>null,
-			'disabled'=>[],
+		$policy=[];
+		if(defined('DATAPHYRE_MODULE_POLICY') && is_array(DATAPHYRE_MODULE_POLICY)){
+			$policy=DATAPHYRE_MODULE_POLICY;
+		}
+		elseif(defined('DATAPHYRE_BOOTSTRAP_CONFIG') && is_array(DATAPHYRE_BOOTSTRAP_CONFIG)){
+			$policy=is_array(DATAPHYRE_BOOTSTRAP_CONFIG['modules'] ?? null)
+				? DATAPHYRE_BOOTSTRAP_CONFIG['modules']
+				: [];
+		}
+		$enabled=self::normalize_module_set(is_array($policy['enabled'] ?? null) ? $policy['enabled'] : []);
+		$disabled=self::normalize_module_set(is_array($policy['disabled'] ?? null) ? $policy['disabled'] : []);
+		foreach($disabled as $module=>$_){
+			unset($enabled[$module]);
+		}
+		unset($disabled['core']);
+		$enabled=['core'=>true]+$enabled;
+		return self::$module_config=[
+			'enabled'=>$enabled,
+			'disabled'=>$disabled,
 		];
-		foreach(self::module_config_sources() as $source){
-			if(!is_array($source)){
-				continue;
-			}
-			if(self::is_list($source)){
-				$config['enabled']=self::normalize_module_list($source);
-				continue;
-			}
-			if(array_key_exists('enabled', $source)){
-				$config['enabled']=is_array($source['enabled'])
-					? self::normalize_module_list($source['enabled'])
-					: null;
-			}
-			if(array_key_exists('disabled', $source) && is_array($source['disabled'])){
-				$config['disabled']=array_values(array_unique(array_merge(
-					$config['disabled'],
-					self::normalize_module_list($source['disabled'])
-				)));
-			}
-		}
-		return self::$module_config=$config;
-	}
-
-	/**
-	 * Reads module configuration payloads from common config, application config, and APP_MODULES.
-	 *
-	 * File sources are required directly so they can return PHP arrays. Missing files are ignored, and APP_MODULES is appended last to act as the highest-level runtime override.
-	 *
-	 * @return array<int,mixed> Raw configuration payloads in precedence order.
-	 */
-	private static function module_config_sources(): array {
-		$sources=[];
-		if(defined('ROOTPATH')){
-			foreach([
-				ROOTPATH['common_dataphyre'].'config/modules.php',
-				ROOTPATH['dataphyre'].'config/modules.php',
-			] as $file){
-				if(is_file($file)){
-					$sources[]=(require $file);
-				}
-			}
-		}
-		if(defined('APP_MODULES')){
-			$sources[]=\constant('APP_MODULES');
-		}
-		return $sources;
-	}
-
-	/**
-	 * Applies enabled and disabled configuration lists to a normalized module name.
-	 *
-	 * Disabled entries always win. When an enabled allow-list is present, modules not listed there are disabled even if they exist on disk.
-	 *
-	 * @param string $module Normalized module name.
-	 * @return bool True when configuration permits the module.
-	 */
-	private static function is_enabled(string $module): bool {
-		$config=self::module_config();
-		if(in_array($module, $config['disabled'], true)){
-			return false;
-		}
-		if(is_array($config['enabled']) && !in_array($module, $config['enabled'], true)){
-			return false;
-		}
-		return true;
-	}
-
-	/**
-	 * Checks whether an application dash-prefixed directory disables a shared module.
-	 *
-	 * A directory such as modules/-sql/ lets an application suppress a common runtime module without editing the shared module tree.
-	 *
-	 * @param string $module Normalized module name.
-	 * @return bool True when the application explicitly disables the module.
-	 */
-	private static function is_app_disabled(string $module): bool {
-		return defined('ROOTPATH')
-			&& !empty(ROOTPATH['dataphyre'])
-			&& is_dir(ROOTPATH['dataphyre'].'modules/-'.$module.'/');
 	}
 
 	/**
@@ -417,49 +334,39 @@ final class module_registry {
 	}
 
 	/**
-	 * Normalizes a module list while preserving first-seen order.
+	 * Normalizes a module list or lookup map into a membership set.
 	 *
 	 * Blank names and duplicate normalized names are discarded so configuration lists remain deterministic and safe for membership checks.
 	 *
-	 * @param array<int,mixed> $modules Raw module names from config.
-	 * @return array<int,string> Unique normalized module names.
+	 * @param array<mixed> $modules Raw module names or normalized lookup map.
+	 * @return array<string,bool> Unique normalized module-name set.
 	 */
-	private static function normalize_module_list(array $modules): array {
-		$normalized=[];
-		$seen=[];
-		foreach($modules as $module){
-			$module=self::normalize_module_name((string)$module);
-			if($module==='' || isset($seen[$module])){
+	private static function normalize_module_set(array $modules): array {
+		$set=[];
+		foreach($modules as $key=>$value){
+			$module=is_string($key) ? $key : (string)$value;
+			if(is_string($key) && $value!==true && $value!==1){
 				continue;
 			}
-			$seen[$module]=true;
-			$normalized[]=$module;
+			$module=self::normalize_module_name($module);
+			if($module!==''){
+				$set[$module]=true;
+			}
 		}
-		return $normalized;
+		return $set;
 	}
 
 	/**
 	 * Normalizes a module name for filesystem and configuration comparisons.
 	 *
-	 * Module names are lowercase and trimmed; no namespace or path validation is performed here.
+	 * Names are lowercase, trimmed, and restricted to safe directory segments.
 	 *
 	 * @param string $module Raw module name.
 	 * @return string Normalized module name.
 	 */
 	private static function normalize_module_name(string $module): string {
-		return strtolower(trim($module));
-	}
-
-	/**
-	 * Determines whether an array is a zero-based list.
-	 *
-	 * This compatibility helper identifies simple APP_MODULES-style enabled lists without relying on newer PHP runtime helpers.
-	 *
-	 * @param array<mixed> $value Candidate array.
-	 * @return bool True when the array keys are exactly 0..n-1.
-	 */
-	private static function is_list(array $value): bool {
-		return array_keys($value)===range(0, count($value)-1);
+		$module=strtolower(trim($module));
+		return preg_match('/^[a-z0-9][a-z0-9_-]*$/', $module)===1 ? $module : '';
 	}
 
 	/**

--- a/runtime/modules/core/kernel/runtime.php
+++ b/runtime/modules/core/kernel/runtime.php
@@ -7,6 +7,14 @@
  */
 namespace dataphyre;
 
+// PHP class names are case-insensitive, so the Framework-facing Runtime API
+// must be composed into this canonical kernel class rather than declared as a
+// second Dataphyre\Runtime class. The conditional include is cycle-safe in
+// both load orders because Framework/Runtime.php uses require_once in return.
+if(!trait_exists('Dataphyre\\RuntimeFrameworkSurface', false)){
+	require_once dirname(__DIR__).'/Framework/Runtime.php';
+}
+
 /**
  * Boots a Dataphyre application from its project root and application definition.
  *
@@ -16,6 +24,7 @@ namespace dataphyre;
  * definition permits it.
  */
 final class runtime {
+	use \Dataphyre\RuntimeFrameworkSurface;
 
 	/**
 	 * Application definition selected by the most recent successful boot.
@@ -50,6 +59,9 @@ final class runtime {
 		self::$current_application_definition=$definition;
 		self::$current_project_root=rtrim($project_root, '/\\');
 		self::register_application_autoload($definition);
+		if(self::boot_internal_runtime_route($definition)===true){
+			return;
+		}
 		if(self::boot_compiled_routes($definition)===true){
 			return;
 		}
@@ -120,6 +132,110 @@ final class runtime {
 			return $conventional_definition->with_overrides($definition);
 		}
 		throw new \RuntimeException("Application definition must return an array or application_definition: {$definition_file}");
+	}
+
+	/**
+	 * Dispatches Dataphyre-owned routes before application route stacks take over.
+	 *
+	 * Framework-only applications do not load the legacy global routing config, so internal
+	 * scheduler callbacks must be recognized at the common runtime boundary. The route is
+	 * intentionally exact, GET-only, internal-traffic-only, and protected by a short-lived
+	 * purpose-bound signature before the scheduling kernel or task file can execute.
+	 *
+	 * @param application_definition $definition Loaded application definition.
+	 * @param array<string,mixed> $runtime Optional deterministic request, verifier, loader, response, and runner seams.
+	 * @return bool `true` when the request belonged to a Dataphyre internal route.
+	 */
+	private static function boot_internal_runtime_route(application_definition $definition, array $runtime=[]): bool {
+		$server=is_array($runtime['server'] ?? null) ? $runtime['server'] : $_SERVER;
+		$scheduler_name=self::scheduler_route_name($server);
+		if($scheduler_name===null){
+			return false;
+		}
+
+		self::prime_rootpaths($definition);
+		$respond=$runtime['respond'] ?? static function(int $status, string $body): void {
+			http_response_code($status);
+			if(!headers_sent()){
+				header('Content-Type: text/plain; charset=utf-8');
+				header('Cache-Control: no-store');
+			}
+			echo $body;
+		};
+		$token=trim((string)($server['HTTP_X_DATAPHYRE_SCHEDULER_KEY'] ?? ''));
+		$dispatch_claim=trim((string)($server['HTTP_X_DATAPHYRE_SCHEDULER_CLAIM'] ?? ''));
+		$verify=$runtime['verify'] ?? static fn(string $candidate, string $name, string $claim): bool =>
+			function_exists('dp_verify_shared_request_key')
+			&& dp_verify_shared_request_key($candidate, 'app_override_key', 'scheduler_dispatch', $name.'|'.$claim, 1);
+		$authorized=strtoupper((string)($server['REQUEST_METHOD'] ?? 'GET'))==='GET'
+			&& (string)($server['HTTP_X_TRAFFIC_SOURCE'] ?? '')==='internal_traffic'
+			&& preg_match('/^[a-f0-9]{64}$/D', $dispatch_claim)===1
+			&& $token!==''
+			&& is_callable($verify)
+			&& $verify($token, $scheduler_name, $dispatch_claim)===true;
+		if($authorized!==true){
+			$respond(404, 'Not found');
+			return true;
+		}
+
+		$core_loader=$runtime['core_loader'] ?? static function(): bool {
+			$core_entry=__DIR__.'/core.main.php';
+			if(!is_file($core_entry)){
+				return false;
+			}
+			require_once $core_entry;
+			return class_exists('dataphyre\\core', false);
+		};
+		if(!is_callable($core_loader) || $core_loader()!==true){
+			$respond(503, 'Scheduler unavailable');
+			return true;
+		}
+
+		$loader=$runtime['module_loader'] ?? static fn(string $module): bool =>
+			method_exists('dataphyre\\core', 'load_framework_module')
+			&& \dataphyre\core::load_framework_module($module);
+		$loaded=is_callable($loader) && $loader('scheduling')===true;
+		$scheduling_available=array_key_exists('scheduling_available', $runtime)
+			? (bool)$runtime['scheduling_available']
+			: class_exists('dataphyre\\scheduling', false);
+		if($loaded!==true && $scheduling_available!==true){
+			$respond(503, 'Scheduler unavailable');
+			return true;
+		}
+
+		$runner=$runtime['task_runner'] ?? static function(string $name, string $claim): void {
+			if(!class_exists('dataphyre_scheduling_task_runner', false)){
+				if(!defined('DATAPHYRE_SCHEDULING_TASK_RUNNER_NO_DISPATCH')){
+					define('DATAPHYRE_SCHEDULING_TASK_RUNNER_NO_DISPATCH', true);
+				}
+				require dirname(__DIR__, 2).'/scheduling/kernel/task_runner.php';
+			}
+			\dataphyre_scheduling_task_runner::dispatch(null, null, [
+				'scheduler_name'=>$name,
+				'scheduler_claim'=>$claim,
+			]);
+		};
+		$runner($scheduler_name, $dispatch_claim);
+		return true;
+	}
+
+	/**
+	 * Extracts one exact path-safe scheduler name from the current request URI.
+	 *
+	 * @param array<string,mixed> $server Request server values.
+	 * @return ?string Scheduler name, or null when this is not the internal scheduler route.
+	 */
+	private static function scheduler_route_name(array $server): ?string {
+		$path=parse_url((string)($server['REQUEST_URI'] ?? '/'), PHP_URL_PATH);
+		if(!is_string($path)){
+			return null;
+		}
+		$path=rawurldecode($path);
+		if(preg_match('#^/dataphyre/scheduler/([A-Za-z0-9._-]{1,128})$#D', $path, $matches)!==1){
+			return null;
+		}
+		$name=(string)$matches[1];
+		return in_array($name, ['.', '..'], true) ? null : $name;
 	}
 
 	/**

--- a/runtime/modules/core/unit_tests/dataphyre.runtime_capability_contracts.test.php
+++ b/runtime/modules/core/unit_tests/dataphyre.runtime_capability_contracts.test.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+/*************************************************************************
+ * Dataphyre
+ *
+ * Copyright (c) 2026 Shopiro Ltd.
+ * SPDX-License-Identifier: MIT
+ */
+
+use Dataphyre\Test\Context;
+use function Dataphyre\Test\framework;
+use function Dataphyre\Test\test;
+
+framework(['core','http','routing','sql','mvc','api','scheduling','stripe']);
+
+if(!function_exists('dataphyre\\tracelog')){
+	\Dataphyre\Test\define_test_symbols(<<<'PHP'
+namespace dataphyre;
+function tracelog(mixed ...$arguments): void {}
+if(!class_exists('routing', false)){
+	final class routing {
+		public static array $bindings=[];
+		public static function valid_scheduler_name(string $name): bool { return $name!==''; }
+		public static function scheduler_route(string $name): string { return '/scheduler/'.$name; }
+	}
+}
+PHP);
+}
+require_once __DIR__.'/../../stripe/kernel/stripe.account_client.php';
+require_once __DIR__.'/../../scheduling/kernel/scheduling.main.php';
+if(!defined('DATAPHYRE_SCHEDULING_TASK_RUNNER_NO_DISPATCH')){
+	define('DATAPHYRE_SCHEDULING_TASK_RUNNER_NO_DISPATCH', true);
+}
+require_once __DIR__.'/../../scheduling/kernel/task_runner.php';
+require_once __DIR__.'/../kernel/runtime.php';
+
+test('runtime capability contracts expose application-neutral framework surfaces', static function(Context $t): void {
+	$required=[
+		'Dataphyre\\Database\\TableDefinition'=>['columnDefinitions'],
+		'Dataphyre\\Mvc\\RouteDefinition'=>['api','apiMetadata'],
+		'Dataphyre\\Mvc\\MvcDispatcher'=>['authorizeApiRoute','executeApiRoute'],
+		'dataphyre\\stripe_account_client'=>['readiness','construct_webhook_event'],
+		'dataphyre\\runtime'=>['boot_internal_runtime_route','scheduler_route_name'],
+		'dataphyre\\scheduling'=>['use_state_root','acquire_running_lock'],
+		'dataphyre_scheduling_task_runner'=>['claimRunningLock'],
+	];
+	foreach($required as $class=>$methods){
+		$t->same(true, class_exists($class, true), $class.' must be available');
+		foreach($methods as $method){
+			$t->same(true, method_exists($class, $method), $class.'::'.$method.' must be available');
+		}
+	}
+})->tag('core','runtime','capability','contract','unit');

--- a/runtime/modules/mvc/Framework/MvcDispatcher.php
+++ b/runtime/modules/mvc/Framework/MvcDispatcher.php
@@ -61,17 +61,27 @@ final class MvcDispatcher {
 					'route_name'=>$route->nameValue(),
 					'app'=>$this->app,
 				]);
+				$authorizationResponse=$this->authorizeApiRoute($match, $request);
+				if($authorizationResponse instanceof Response){
+					return $this->normalizeResponse($authorizationResponse);
+				}
 				$terminable=[];
 				try{
 					$response=$this->normalizeResponse($this->runMiddleware(
 						$this->middlewareStack($match['middleware'] ?? [], $route->excludedMiddlewareDefinitions()),
 						$request,
-						fn(Request $request): Response => $this->normalizeResponse($this->invokeHandler(
-							$route->handler(),
-							$request,
-							new MvcRouteContext($this->app, $route, $match, $parameters),
-							$terminable
-						)),
+						function(Request $request) use ($route, $match, $parameters, &$terminable): Response {
+							$apiResponse=$this->executeApiRoute($match, $request);
+							if($apiResponse instanceof Response){
+								return $this->normalizeResponse($apiResponse);
+							}
+							return $this->normalizeResponse($this->invokeHandler(
+								$route->handler(),
+								$request,
+								new MvcRouteContext($this->app, $route, $match, $parameters),
+								$terminable
+							));
+						},
 						$terminable
 					));
 				}catch(\Throwable $throwable){
@@ -84,6 +94,56 @@ final class MvcDispatcher {
 		}catch(\Throwable $throwable){
 			return $this->handleError($throwable, $request);
 		}
+	}
+
+	/** @param array<string,mixed> $route */
+	private function authorizeApiRoute(array $route, Request $request): ?Response {
+		$api=$route['api'] ?? null;
+		if(!is_array($api)){
+			return null;
+		}
+		$security=$api['security'] ?? [];
+		if(!is_array($security) || $security===[]){
+			return null;
+		}
+		if($this->loadApiBridge('authorizeCompiledRoute')!==true){
+			return $this->apiBridgeUnavailable();
+		}
+		$response=\Dataphyre\Api\Api::authorizeCompiledRoute($route, $request);
+		return $response instanceof Response ? $response : null;
+	}
+
+	/** @param array<string,mixed> $route */
+	private function executeApiRoute(array $route, Request $request): ?Response {
+		if(!is_array($route['api'] ?? null) || !is_array($route['api']['execution'] ?? null)){
+			return null;
+		}
+		if($this->loadApiBridge('executeCompiledRoute')!==true){
+			return $this->apiBridgeUnavailable();
+		}
+		$response=\Dataphyre\Api\Api::executeCompiledRoute($route, $request);
+		return $response instanceof Response ? $response : null;
+	}
+
+	/** Loads the API framework for a declared bridge operation without allowing a security fallback. */
+	private function loadApiBridge(string $method): bool {
+		try{
+			if(class_exists('\dataphyre\core', false)){
+				\dataphyre\core::load_framework_module('api');
+			}
+			return class_exists('\Dataphyre\Api\Api')
+				&& method_exists('\Dataphyre\Api\Api', $method);
+		}catch(\Throwable){
+			return false;
+		}
+	}
+
+	/** Returns a stable fail-closed response when declared API behavior cannot run. */
+	private function apiBridgeUnavailable(): Response {
+		return Response::json([
+			'ok'=>false,
+			'error'=>'API framework is unavailable.',
+		], 503, ['Cache-Control'=>'no-store']);
 	}
 
 	/**
@@ -150,7 +210,7 @@ final class MvcDispatcher {
 		}
 		$manifest=$this->app->routes()->compile([
 			'signature'=>$signature,
-			'route_sources'=>$this->app->routeSources(),
+			'route_sources'=>$this->manifestSources(),
 		]);
 		if($cacheFile!==null){
 			$this->writeManifestCache($cacheFile, $manifest);
@@ -168,8 +228,15 @@ final class MvcDispatcher {
 		return RouteCompiler::manifestSignature([
 			'app'=>$this->app->name(),
 			'revision'=>$revision,
-			'sources'=>$this->app->routeSources(),
+			'sources'=>$this->manifestSources(),
 		]);
+	}
+
+	/** @return array<string,int> Route files plus declared cache dependencies. */
+	private function manifestSources(): array {
+		$sources=array_replace($this->app->routeSources(), $this->app->manifestCacheSources());
+		ksort($sources, SORT_STRING);
+		return $sources;
 	}
 
 	/**

--- a/runtime/modules/mvc/Framework/RouteDefinition.php
+++ b/runtime/modules/mvc/Framework/RouteDefinition.php
@@ -31,6 +31,7 @@ final class RouteDefinition implements CompilableRoute {
 	private array $modelBindings=[];
 	private array $constraints=[];
 	private array $defaults=[];
+	private ?array $apiMetadata=null;
 	private ?string $name=null;
 	private ?string $domain=null;
 	private string $namePrefix='';
@@ -167,9 +168,49 @@ final class RouteDefinition implements CompilableRoute {
 		$name=trim($name);
 		if($name!==''){
 			$this->name=$this->namePrefix.$name;
+			if($this->apiMetadata!==null){
+				if(trim((string)($this->apiMetadata['operation_id'] ?? ''))===''){
+					$this->apiMetadata['operation_id']=$this->name;
+				}
+				$aliases=is_array($this->apiMetadata['aliases'] ?? null) ? $this->apiMetadata['aliases'] : [];
+				if(!in_array($this->name, $aliases, true)){
+					$aliases[]=$this->name;
+				}
+				$this->apiMetadata['aliases']=array_values($aliases);
+			}
 			$this->changed();
 		}
 		return $this;
+	}
+
+	/**
+	 * Attaches Dataphyre API endpoint metadata to this MVC route.
+	 *
+	 * MVC keeps controller resolution and middleware ownership while the API
+	 * framework owns authorization, discovery, bindings, caching, and execution.
+	 * One compiled route manifest can therefore serve both frameworks.
+	 *
+	 * @param array<string,mixed> $metadata Compiled Endpoint API metadata.
+	 */
+	public function api(array $metadata): self {
+		$this->apiMetadata=$metadata;
+		if($this->name!==null){
+			if(trim((string)($this->apiMetadata['operation_id'] ?? ''))===''){
+				$this->apiMetadata['operation_id']=$this->name;
+			}
+			$aliases=is_array($this->apiMetadata['aliases'] ?? null) ? $this->apiMetadata['aliases'] : [];
+			if(!in_array($this->name, $aliases, true)){
+				$aliases[]=$this->name;
+			}
+			$this->apiMetadata['aliases']=array_values($aliases);
+		}
+		$this->changed();
+		return $this;
+	}
+
+	/** @return ?array<string,mixed> Attached API metadata, or null for a regular MVC route. */
+	public function apiMetadata(): ?array {
+		return $this->apiMetadata;
 	}
 
 	/**
@@ -511,7 +552,11 @@ final class RouteDefinition implements CompilableRoute {
 		if($this->defaults!==[]){
 			$route->defaults($this->defaults);
 		}
-		return $route->compile();
+		$compiled=$route->compile();
+		if($this->apiMetadata!==null){
+			$compiled['api']=$this->apiMetadata;
+		}
+		return $compiled;
 	}
 
 	/**

--- a/runtime/modules/scheduling/kernel/scheduling.main.php
+++ b/runtime/modules/scheduling/kernel/scheduling.main.php
@@ -27,6 +27,13 @@ class scheduling {
 	private const CACHE_PATH='cache/scheduling/';
 	/** @var ?string Scheduler currently being executed by a task runner route in this process. */
 	private static ?string $active_scheduler_name=null;
+	/** @var ?string Optional embedded-runtime state root override. */
+	private static ?string $state_root=null;
+
+	/** Selects an alternate scheduler state root for embedded and isolated runtimes. */
+	public static function use_state_root(?string $root): void {
+		self::$state_root=$root===null ? null : rtrim($root, '/\\').'/';
+	}
 
     /**
      * Registers a scheduler definition and dispatches it after shutdown when it is due.
@@ -43,9 +50,10 @@ class scheduling {
      * @param string $memory_limit Memory limit stored with the scheduler definition.
      * @param array<int, string> $dependencies Files that must exist before the scheduler is accepted.
      * @param ?string $app_override Application override to preserve in the internal dispatch request.
+     * @param ?callable $shutdown_registrar Optional shutdown registrar used by embedded runtimes and tests.
      * @return bool Whether the scheduler definition was accepted and persisted.
      */
-    public static function run(string $name, string $file_path, float $frequency, float $timeout, string $memory_limit, array $dependencies, ?string $app_override=null) : bool {
+    public static function run(string $name, string $file_path, float $frequency, float $timeout, string $memory_limit, array $dependencies, ?string $app_override=null, ?callable $shutdown_registrar=null) : bool {
 		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null); // Log the function call
 		if(!isset($app_override))$app_override=APP;
 		$name=self::normalize_scheduler_name($name);
@@ -67,15 +75,52 @@ class scheduling {
 		}
 		self::persist_scheduler_definition($scheduler);
 		if(self::can_run($scheduler)===true){
-			core::file_put_contents_forced(self::last_run_file($name), (string)time());
-			if(false!==core::file_put_contents_forced(self::running_lock_file($name), '')){
-				register_shutdown_function([self::class, 'dispatch_registered_scheduler'], $name, $app_override);
-			}
-			else
-			{
-				tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $S='Failed locking scheduler');
+			try{
+				$dispatch_claim=bin2hex(random_bytes(32));
+			}catch(\Throwable $failure){
+				tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $S='Failed creating scheduler dispatch claim', $T='warning');
 				return false;
 			}
+			if(self::acquire_running_lock($name, $dispatch_claim)!==true){
+				tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $S='Failed atomically locking scheduler', $T='warning');
+				return false;
+			}
+			if(core::file_put_contents_forced(self::last_run_file($name), (string)time())===false){
+				@unlink(self::running_lock_file($name));
+				tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $S='Failed recording scheduler dispatch timestamp', $T='warning');
+				return false;
+			}
+			$shutdown_registrar ??= static function(mixed $callback, mixed ...$arguments): void {
+				register_shutdown_function($callback, ...$arguments);
+			};
+			$shutdown_registrar([self::class, 'dispatch_registered_scheduler'], $name, $app_override, $dispatch_claim);
+		}
+		return true;
+	}
+
+	/**
+	 * Creates one pending-dispatch lock without overwriting a concurrent claim.
+	 *
+	 * The exclusive-create filesystem primitive is the scheduler's process boundary:
+	 * only the request that creates the lock receives the claim and may register the
+	 * shutdown dispatch. The task runner later takes an advisory lock on the same
+	 * file, which prevents a valid signed callback from being replayed concurrently.
+	 */
+	private static function acquire_running_lock(string $name, string $dispatch_claim): bool {
+		if(preg_match('/^[a-f0-9]{64}$/D', $dispatch_claim)!==1){
+			return false;
+		}
+		$path=self::running_lock_file($name);
+		$handle=@fopen($path, 'x');
+		if(!is_resource($handle)){
+			return false;
+		}
+		$written=@fwrite($handle, $dispatch_claim);
+		$flushed=$written===strlen($dispatch_claim) && @fflush($handle);
+		@fclose($handle);
+		if($flushed!==true){
+			@unlink($path);
+			return false;
 		}
 		return true;
 	}
@@ -137,7 +182,8 @@ class scheduling {
 	 */
 	public static function scheduler_directory(string $name): string {
 		$name=self::normalize_scheduler_name($name);
-		return ROOTPATH['dataphyre'].self::CACHE_PATH.($name!=='' ? $name.'/' : '');
+		$root=self::$state_root ?? (string)ROOTPATH['dataphyre'];
+		return rtrim($root, '/\\').'/'.self::CACHE_PATH.($name!=='' ? $name.'/' : '');
 	}
 
 	/**
@@ -247,16 +293,36 @@ class scheduling {
 	 *
 	 * @param string $name Scheduler name to dispatch.
 	 * @param string $app_override Application override to include when resolvable.
+	 * @param string $dispatch_claim One-time pending-dispatch claim stored in the scheduler lock.
+	 * @param ?bool $curl_available Optional transport override used by deterministic runtimes.
+	 * @param ?callable $signer Optional scheduler-name and claim signer used by deterministic runtimes.
 	 */
-	private static function dispatch_registered_scheduler(string $name, string $app_override): void {
+	private static function dispatch_registered_scheduler(string $name, string $app_override, string $dispatch_claim, ?bool $curl_available=null, ?callable $signer=null): void {
 		try{
 			$url=self::scheduler_dispatch_url($name, $app_override);
 			if($url===null){
 				tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $S='Unable to resolve scheduler dispatch URL', $T='warning');
 				return;
 			}
-			$headers=['X-Traffic-Source: internal_traffic'];
-			if(function_exists('curl_init')){
+			if(preg_match('/^[a-f0-9]{64}$/D', $dispatch_claim)!==1){
+				tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $S='Invalid scheduler dispatch claim', $T='warning');
+				return;
+			}
+			$signer ??= function_exists('dp_shared_request_key')
+				? static fn(string $scheduler, string $claim): string|false=>dp_shared_request_key('app_override_key', 'scheduler_dispatch', $scheduler.'|'.$claim)
+				: null;
+			$request_key=is_callable($signer) ? $signer($name, $dispatch_claim) : false;
+			if(!is_string($request_key) || preg_match('/^[a-f0-9]{64}$/D', $request_key)!==1){
+				tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $S='Unable to sign internal scheduler dispatch', $T='warning');
+				return;
+			}
+			$headers=[
+				'X-Traffic-Source: internal_traffic',
+				'X-Dataphyre-Scheduler-Claim: '.$dispatch_claim,
+				'X-Dataphyre-Scheduler-Key: '.$request_key,
+			];
+			$curl_available ??= function_exists('curl_init');
+			if($curl_available){
 				$ch=curl_init();
 				curl_setopt($ch, CURLOPT_URL, $url);
 				curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
@@ -317,7 +383,10 @@ class scheduling {
 	 */
 	private static function normalize_scheduler_name(string $name): string {
 		$name=trim($name);
-		if($name==='' || preg_match('/^[A-Za-z0-9._-]+$/', $name)!==1){
+		if(
+			$name==='' || strlen($name)>128 || in_array($name, ['.', '..'], true)
+			|| preg_match('/^[A-Za-z0-9._-]+$/D', $name)!==1
+		){
 			return '';
 		}
 		return $name;
@@ -378,7 +447,11 @@ class scheduling {
 		$file_path=realpath((string)($scheduler['file_path'] ?? '')) ?: (string)($scheduler['file_path'] ?? '');
 		$dependencies=[];
 		foreach((array)($scheduler['dependencies'] ?? []) as $dependency){
-			$dependency_path=realpath((string)$dependency) ?: (string)$dependency;
+			$dependency=(string)$dependency;
+			if(trim($dependency)===''){
+				continue;
+			}
+			$dependency_path=realpath($dependency) ?: $dependency;
 			if($dependency_path!==''){
 				$dependencies[$dependency_path]=true;
 			}
@@ -418,11 +491,12 @@ class scheduling {
 	 * @param string $last_run_file Absolute last_run path.
 	 * @return ?int Positive timestamp, or null when missing or invalid.
 	 */
-	private static function read_last_run_timestamp(string $last_run_file): ?int {
+	private static function read_last_run_timestamp(string $last_run_file, ?callable $reader=null): ?int {
 		if(!is_file($last_run_file)){
 			return null;
 		}
-		$contents=@file_get_contents($last_run_file);
+		$reader ??= static fn(string $path): string|false => @file_get_contents($path);
+		$contents=$reader($last_run_file);
 		if(!is_string($contents)){
 			return null;
 		}

--- a/runtime/modules/scheduling/kernel/task_runner.php
+++ b/runtime/modules/scheduling/kernel/task_runner.php
@@ -5,98 +5,220 @@
  * Copyright (c) 2025 Shopiro Ltd.
  * SPDX-License-Identifier: MIT
  */
-$scheduler_name=(string)(\dataphyre\routing::$bindings['scheduler'] ?? '');
-if(!class_exists('dataphyre\\scheduling', false) || !dataphyre\scheduling::valid_scheduler_name($scheduler_name)){
-	http_response_code(400);
-	echo'Invalid scheduler';
-	die();
-}
-$scheduler_path=dataphyre\scheduling::scheduler_directory($scheduler_name);
-$running_lock_file=dataphyre\scheduling::running_lock_file($scheduler_name);
-if(!is_file($running_lock_file)){
-	if(method_exists("dataphyre\core", "unavailable")){
-		dataphyre\core::unavailable(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $S='Failed setting scheduler task lock at runtime', $T='safemode');
-	}
-}
-$scheduler_properties_file=dataphyre\scheduling::scheduler_properties_file($scheduler_name);
-$scheduler=dataphyre\scheduling::read_scheduler($scheduler_name);
-if($scheduler===null){
-	if(method_exists("dataphyre\core", "dialback")){
-		$task=["scheduler"=>$scheduler];
-		dataphyre\core::dialback("CALL_SCHEDULING_TASK_FAILED",$task);
-	}
-	if(function_exists("pre_init_error")){
-		pre_init_error('Fatal error: scheduler does not exist ('.$scheduler_name.' at '.$scheduler_properties_file.')');
-	}
-	echo'Requested scheduler does not exist';
-	die();
-}
 
-dataphyre\scheduling::begin_task_runner($scheduler_name);
-	
-try{
-	$timeout=max(1, (int)ceil((float)($scheduler['timeout'] ?? 1)));
-	@set_time_limit($timeout);
-	@ini_set('max_execution_time', (string)$timeout);
-	@ini_set('memory_limit', (string)($scheduler['memory_limit'] ?? '128M'));
-	foreach($scheduler['dependencies'] as $dependency){
-		if(!is_string($dependency) || $dependency==='' || !is_file($dependency)){
-			throw new \RuntimeException('Scheduler dependency does not exist: '.(string)$dependency);
-		}
-		if(defined('IS_PRODUCTION') && IS_PRODUCTION===false) echo'Including '.$dependency.'<br>';
-		require_once($dependency);
-	}
-	if(function_exists("dp_module_present") && dp_module_present('tracelog')){
-		new dataphyre\tracelog;
-		dataphyre\tracelog::$enable=true;
-	}
-	if(function_exists("dp_module_present") && dp_module_present('sql')){
-		\dp_define_module_config('sql', 'DP_SQL_CFG');
-		$default_cache_policy=is_array(DP_SQL_CFG['caching']['default_policy'] ?? null)
-			? DP_SQL_CFG['caching']['default_policy']
-			: ['type'=>'session', 'max_lifespan'=>'30 minute', 'hash_type'=>'md5'];
-		$default_cache_policy['type']=dp_module_present('cache') ? 'shared_cache' : 'fs';
-		if(!defined('DP_SQL_DEFAULT_CACHE_POLICY_OVERRIDE')){
-			define('DP_SQL_DEFAULT_CACHE_POLICY_OVERRIDE', $default_cache_policy);
-		}
-	}
-	if(!is_string($scheduler['file_path']) || $scheduler['file_path']==='' || !is_file($scheduler['file_path'])){
-		throw new \RuntimeException('Scheduler file does not exist: '.(string)($scheduler['file_path'] ?? ''));
-	}
-	if(defined('IS_PRODUCTION') && IS_PRODUCTION===false) echo 'Running '.$scheduler['file_path'].'<br>';
-	require_once($scheduler['file_path']);
-}catch(Throwable $e){
-	if(method_exists("dataphyre\core", "dialback")){
-		$task=["scheduler"=>$scheduler];
-		dataphyre\core::dialback("CALL_SCHEDULING_TASK_FAILED", $task);
-	}
-	if(function_exists("pre_init_error")){
-		pre_init_error('Fatal error: scheduler task failed ('.$scheduler_name.')', $e);
-	}
-	echo'Execution error';
-}
+/** Executes one persisted scheduler definition through the internal task route. */
+final class dataphyre_scheduling_task_runner {
 
-register_shutdown_function(function()use($scheduler_path, $scheduler_name){
-	try{
-		$running_lock_file=dataphyre\scheduling::running_lock_file($scheduler_name);
-		$last_run_file=dataphyre\scheduling::last_run_file($scheduler_name);
-		if(\dp_module_present('tracelog')){
-			file_put_contents($scheduler_path.'/tracelog.html', dataphyre\tracelog::$tracelog, LOCK_EX);
-			echo '<br>';
-			echo '<br>';
-			if(defined('IS_PRODUCTION') && IS_PRODUCTION===false) echo dataphyre\tracelog::$tracelog;
+	/** Dispatches the mounted task route unless an embedding runtime disabled it. */
+	public static function dispatch_entrypoint(
+		bool $no_dispatch,
+		?callable $terminator=null,
+		?callable $shutdown_registrar=null,
+		array $runtime=[],
+	): void {
+		self::loadSchedulingFramework($runtime);
+		if($no_dispatch!==true){
+			self::dispatch($terminator,$shutdown_registrar,$runtime);
 		}
-		file_put_contents($last_run_file, time(), LOCK_EX);
-		if(is_file($running_lock_file)){
-			@unlink($running_lock_file);
+	}
+
+	/** Loads the policy-enabled scheduler kernel for the internal task route. */
+	private static function loadSchedulingFramework(array $runtime): void {
+		$loaded=array_key_exists('scheduling_loaded', $runtime)
+			? (bool)$runtime['scheduling_loaded']
+			: class_exists('dataphyre\\scheduling', false);
+		if($loaded) return;
+		$loader=$runtime['framework_loader'] ?? static fn(string $module): bool => method_exists('dataphyre\\core', 'load_framework_module')
+			? \dataphyre\core::load_framework_module($module)
+			: false;
+		$loader('scheduling');
+	}
+
+	/**
+	 * Validates, executes, and schedules cleanup for one scheduler request.
+	 *
+	 * @param ?callable $terminator Deterministic replacement for the legacy exit boundary.
+	 * @param ?callable $shutdown_registrar Deterministic shutdown callback registrar.
+	 * @param array<string,mixed> $runtime Optional request and dependency observations.
+	 */
+	public static function dispatch(?callable $terminator=null, ?callable $shutdown_registrar=null, array $runtime=[]): void {
+		$ignore_user_abort=$runtime['ignore_user_abort'] ?? static fn(bool $ignore): int => ignore_user_abort($ignore);
+		$ignore_user_abort(true);
+		$scheduler_name=(string)($runtime['scheduler_name'] ?? (\dataphyre\routing::$bindings['scheduler'] ?? ''));
+		$scheduling_available=array_key_exists('scheduling_available',$runtime)
+			? (bool)$runtime['scheduling_available']
+			: class_exists('dataphyre\\scheduling', false);
+		if($scheduling_available!==true || !\dataphyre\scheduling::valid_scheduler_name($scheduler_name)){
+			http_response_code(400);
+			echo 'Invalid scheduler';
+			self::terminate($terminator);
+			return;
 		}
-		if(file_exists($running_lock_file)){
-			if(method_exists("dataphyre\core", "unavailable")){
-				dataphyre\core::unavailable(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $S='Failed unsetting scheduler task lock', $T='safemode');
+
+		$scheduler_path=\dataphyre\scheduling::scheduler_directory($scheduler_name);
+		$running_lock_file=\dataphyre\scheduling::running_lock_file($scheduler_name);
+		$is_file=$runtime['is_file'] ?? static fn(string $path): bool => is_file($path);
+		$scheduler_properties_file=\dataphyre\scheduling::scheduler_properties_file($scheduler_name);
+		$scheduler=\dataphyre\scheduling::read_scheduler($scheduler_name);
+		if($scheduler===null){
+			self::dialback_failure($scheduler);
+			self::pre_init_failure(
+				'Fatal error: scheduler does not exist ('.$scheduler_name.' at '.$scheduler_properties_file.')',
+				null,
+				$runtime,
+			);
+			echo 'Requested scheduler does not exist';
+			self::terminate($terminator);
+			return;
+		}
+		$dispatch_claim=trim((string)($runtime['scheduler_claim'] ?? ''));
+		$claim_handle=self::claimRunningLock($running_lock_file, $dispatch_claim, $runtime);
+		if(!is_resource($claim_handle)){
+			http_response_code(409);
+			self::dialback_failure($scheduler);
+			self::pre_init_failure('Scheduler dispatch is not pending or was already claimed ('.$scheduler_name.')',null,$runtime);
+			echo 'Scheduler not pending';
+			self::terminate($terminator);
+			return;
+		}
+
+		\dataphyre\scheduling::begin_task_runner($scheduler_name);
+		try{
+			$timeout=max(1,(int)ceil((float)($scheduler['timeout'] ?? 1)));
+			@set_time_limit($timeout);
+			@ini_set('max_execution_time',(string)$timeout);
+			@ini_set('memory_limit',(string)($scheduler['memory_limit'] ?? '128M'));
+			foreach($scheduler['dependencies'] as $dependency){
+				if(!is_string($dependency) || $dependency==='' || $is_file($dependency)!==true){
+					throw new \RuntimeException('Scheduler dependency does not exist: '.(string)$dependency);
+				}
+				if(defined('IS_PRODUCTION') && IS_PRODUCTION===false){echo 'Including '.$dependency.'<br>';}
+				require_once $dependency;
 			}
+			if(self::module_present('tracelog',$runtime)){
+				new \dataphyre\tracelog();
+				\dataphyre\tracelog::$enable=true;
+			}
+			if(self::module_present('sql',$runtime)){
+				\dp_define_module_config('sql','DP_SQL_CFG');
+				$default_cache_policy=is_array(DP_SQL_CFG['caching']['default_policy'] ?? null)
+					? DP_SQL_CFG['caching']['default_policy']
+					: ['type'=>'session','max_lifespan'=>'30 minute','hash_type'=>'md5'];
+				$default_cache_policy['type']=self::module_present('cache',$runtime) ? 'shared_cache' : 'fs';
+				if(!defined('DP_SQL_DEFAULT_CACHE_POLICY_OVERRIDE')){
+					define('DP_SQL_DEFAULT_CACHE_POLICY_OVERRIDE',$default_cache_policy);
+				}
+			}
+			if(!is_string($scheduler['file_path']) || $scheduler['file_path']==='' || $is_file($scheduler['file_path'])!==true){
+				throw new \RuntimeException('Scheduler file does not exist: '.(string)($scheduler['file_path'] ?? ''));
+			}
+			if(defined('IS_PRODUCTION') && IS_PRODUCTION===false){echo 'Running '.$scheduler['file_path'].'<br>';}
+			require_once $scheduler['file_path'];
+		}catch(\Throwable $failure){
+			self::dialback_failure($scheduler);
+			self::pre_init_failure('Fatal error: scheduler task failed ('.$scheduler_name.')',$failure,$runtime);
+			echo 'Execution error';
 		}
-		dataphyre\scheduling::end_task_runner();
-	}catch(\Throwable $exception){
-		\dataphyre_shutdown_log('Fatal error on Dataphyre Scheduling (task runner) shutdown callback', $exception);
+
+		$callback=static fn()=>self::finalize($scheduler_path,$scheduler_name,$runtime,$claim_handle);
+		if($shutdown_registrar===null){
+			register_shutdown_function($callback);
+		}else{
+			$shutdown_registrar($callback);
+		}
 	}
-});
+
+	/** Performs the lock, timestamp, trace, and active-state shutdown cleanup. */
+	public static function finalize(string $scheduler_path, string $scheduler_name, array $runtime=[], mixed $claim_handle=null): void {
+		try{
+			$running_lock_file=\dataphyre\scheduling::running_lock_file($scheduler_name);
+			$last_run_file=\dataphyre\scheduling::last_run_file($scheduler_name);
+			$writer=$runtime['writer'] ?? static fn(string $path,mixed $value,int $flags=0): int|false => file_put_contents($path,$value,$flags);
+			$is_file=$runtime['is_file'] ?? static fn(string $path): bool => is_file($path);
+			$file_exists=$runtime['file_exists'] ?? static fn(string $path): bool => file_exists($path);
+			$unlink=$runtime['unlink'] ?? static fn(string $path): bool => @unlink($path);
+			if(self::module_present('tracelog',$runtime)){
+				$writer($scheduler_path.'/tracelog.html',\dataphyre\tracelog::$tracelog,LOCK_EX);
+				echo '<br><br>';
+				if(defined('IS_PRODUCTION') && IS_PRODUCTION===false){echo \dataphyre\tracelog::$tracelog;}
+			}
+			$writer($last_run_file,$runtime['timestamp'] ?? time(),LOCK_EX);
+			if($is_file($running_lock_file)){
+				$unlink($running_lock_file);
+			}
+			if(is_resource($claim_handle)){
+				@flock($claim_handle, LOCK_UN);
+				@fclose($claim_handle);
+			}
+			if($file_exists($running_lock_file) && method_exists('dataphyre\\core','unavailable')){
+				\dataphyre\core::unavailable(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $S='Failed unsetting scheduler task lock', $T='safemode');
+			}
+			\dataphyre\scheduling::end_task_runner();
+		}catch(\Throwable $failure){
+			$logger=$runtime['shutdown_logger'] ?? static fn(string $message,\Throwable $exception): mixed => \dataphyre_shutdown_log($message,$exception);
+			$logger('Fatal error on Dataphyre Scheduling (task runner) shutdown callback',$failure);
+		}
+	}
+
+	/**
+	 * Claims the one pending dispatch and holds the claim lock through cleanup.
+	 *
+	 * The HMAC-authenticated claim must match the exclusive-create lock contents.
+	 * A non-blocking advisory lock makes a captured callback unrepeatable while
+	 * the first runner is executing, including across separate PHP workers.
+	 *
+	 * @return resource|false Locked handle, or false when no exact pending claim exists.
+	 */
+	private static function claimRunningLock(string $path, string $dispatch_claim, array $runtime=[]): mixed {
+		if(preg_match('/^[a-f0-9]{64}$/D', $dispatch_claim)!==1){
+			return false;
+		}
+		$opener=$runtime['lock_opener'] ?? static fn(string $lock_path): mixed => @fopen($lock_path, 'r+');
+		$handle=is_callable($opener) ? $opener($path) : false;
+		if(!is_resource($handle)){
+			return false;
+		}
+		$locker=$runtime['lock_acquirer'] ?? static fn(mixed $lock_handle): bool => @flock($lock_handle, LOCK_EX|LOCK_NB);
+		if(!is_callable($locker) || $locker($handle)!==true){
+			@fclose($handle);
+			return false;
+		}
+		@rewind($handle);
+		$stored=trim((string)stream_get_contents($handle));
+		if(preg_match('/^[a-f0-9]{64}$/D', $stored)!==1 || !hash_equals($stored, $dispatch_claim)){
+			@flock($handle, LOCK_UN);
+			@fclose($handle);
+			return false;
+		}
+		return $handle;
+	}
+
+	private static function module_present(string $module, array $runtime): bool {
+		if(isset($runtime['module_present']) && is_callable($runtime['module_present'])){
+			return (bool)$runtime['module_present']($module);
+		}
+		return function_exists('dp_module_present') && (bool)\dp_module_present($module);
+	}
+
+	private static function dialback_failure(?array $scheduler): void {
+		if(method_exists('dataphyre\\core','dialback')){
+			\dataphyre\core::dialback('CALL_SCHEDULING_TASK_FAILED',['scheduler'=>$scheduler]);
+		}
+	}
+
+	private static function pre_init_failure(string $message, ?\Throwable $failure, array $runtime): void {
+		$handler=$runtime['pre_init_error'] ?? (function_exists('pre_init_error') ? 'pre_init_error' : null);
+		if(is_callable($handler)){
+			$failure===null ? $handler($message) : $handler($message,$failure);
+		}
+	}
+
+	private static function terminate(?callable $terminator): void {
+		if($terminator===null){exit;}
+		$terminator();
+	}
+}
+
+dataphyre_scheduling_task_runner::dispatch_entrypoint(
+	defined('DATAPHYRE_SCHEDULING_TASK_RUNNER_NO_DISPATCH')===true,
+);

--- a/runtime/modules/sql/Framework/TableDefinition.php
+++ b/runtime/modules/sql/Framework/TableDefinition.php
@@ -345,6 +345,7 @@ final class TableDefinition {
 		$this->columns[$name]['inline_primary']=true;
 		$this->columns[$name]['cast']='int';
 		$this->casts[$name]='int';
+		$this->primaryColumns=[$name];
 		return $this;
 	}
 
@@ -571,6 +572,19 @@ final class TableDefinition {
 	}
 
 	/**
+	 * Returns the normalized definition metadata for every declared column.
+	 *
+	 * Schema-aware consumers such as Dataphyre Panel can use this read-only
+	 * snapshot to derive field types, defaults, nullability, and generated-column
+	 * behavior without reaching into the SQL builder's private state.
+	 *
+	 * @return array<string, array<string, mixed>> Column definitions keyed by name.
+	 */
+	public function columnDefinitions(): array {
+		return $this->columns;
+	}
+
+	/**
 	 * Returns primary key columns.
 	 *
 	 * @return array<int, string> Primary key columns in configured order.
@@ -601,8 +615,9 @@ final class TableDefinition {
 	 * Executes schema creation queries for this table definition.
 	 *
 	 * Required create-schema/create-table queries must succeed; optional index queries
-	 * are attempted after table creation. An active data environment takes precedence
-	 * over the table's ordinary cluster so sandbox hydration cannot mutate live schema.
+	 * are attempted after table creation. An active DataEnvironment cluster takes
+	 * precedence over the table's ordinary DP_SQL_CFG cluster so runtime hydration
+	 * cannot leak schema changes into the live database.
 	 *
 	 * @return bool True when required hydration queries succeed.
 	 */
@@ -658,7 +673,7 @@ final class TableDefinition {
 		return false;
 	}
 
-	/** Resolves schema changes through the active data environment before defaults. */
+	/** Resolve schema hydration against the ambient data environment first. */
 	private function hydrationCluster(): string {
 		$environmentCluster=class_exists(DataEnvironment::class)
 			? DataEnvironment::clusterOverride()

--- a/runtime/modules/stripe/kernel/stripe.account_client.php
+++ b/runtime/modules/stripe/kernel/stripe.account_client.php
@@ -1,0 +1,449 @@
+<?php
+/*************************************************************************
+ * Dataphyre
+ *
+ * Copyright (c) 2025 Shopiro Ltd.
+ * SPDX-License-Identifier: MIT
+ */
+namespace dataphyre;
+
+/**
+ * Account-isolated Stripe client for application-owned payment domains.
+ *
+ * Unlike the legacy static stripe facade, this boundary never writes the
+ * account key to Stripe's process-global configuration. Each instance owns a
+ * validated key and a lazy StripeClient, or delegates through an injected
+ * executor/client seam for deterministic tests and custom transports.
+ */
+final class stripe_account_client {
+	private string $secret_key;
+	private ?\Closure $executor;
+	private ?object $client;
+	/** @var array<string, mixed> */
+	private array $request_options;
+
+	/**
+	 * @param array<string, mixed> $request_options Stripe request options shared by calls.
+	 */
+	public function __construct(
+		string $secret_key,
+		?callable $executor=null,
+		?object $client=null,
+		array $request_options=[],
+	) {
+		$metadata=self::key_metadata($secret_key);
+		if($metadata===null){
+			throw new \InvalidArgumentException('Stripe account key is missing or invalid.');
+		}
+		if($executor!==null && $client!==null){
+			throw new \InvalidArgumentException('Stripe account client accepts either an executor or a client, not both.');
+		}
+		$this->secret_key=trim($secret_key);
+		$this->executor=$executor===null ? null : \Closure::fromCallable($executor);
+		$this->client=$client;
+		$this->request_options=self::normalize_request_options($request_options);
+	}
+
+	/**
+	 * Returns local configuration readiness without contacting Stripe.
+	 *
+	 * @return array<string, bool|string>
+	 */
+	public function readiness(): array {
+		$metadata=self::key_metadata($this->secret_key);
+		$sdk_available=$this->sdk_available();
+		return [
+			'ready'=>$metadata!==null && $sdk_available,
+			'configured'=>true,
+			'valid'=>$metadata!==null,
+			'mode'=>(string)($metadata['mode'] ?? 'unknown'),
+			'key_type'=>(string)($metadata['key_type'] ?? 'unknown'),
+			'sdk_available'=>$sdk_available,
+			'network_checked'=>false,
+			'executor_injected'=>$this->executor!==null,
+			'client_injected'=>$this->client!==null,
+		];
+	}
+
+	/** Resolves SDK availability through injectable probes without changing the public readiness API. */
+	private function sdk_available(?callable $class_probe=null, ?callable $file_probe=null): bool {
+		$class_probe??=static fn(string $class): bool=>class_exists($class, false);
+		$file_probe??=static fn(string $path): bool=>is_file($path);
+		return $this->executor!==null
+			|| $this->client!==null
+			|| $class_probe('\\Stripe\\StripeClient')
+			|| $file_probe(dirname(__DIR__).'/src/init.php');
+	}
+
+	/** @param array<string, mixed> $params */
+	public function create_customer(array $params, string $idempotency=''): mixed {
+		return $this->execute('customers.create', [$params], $this->options($idempotency));
+	}
+
+	/** @param array<string, mixed> $params */
+	public function update_customer(string $customer_id, array $params, string $idempotency=''): mixed {
+		self::require_identifier($customer_id, 'cus', 'customer');
+		return $this->execute('customers.update', [$customer_id, $params], $this->options($idempotency));
+	}
+
+	public function retrieve_customer(string $customer_id): mixed {
+		self::require_identifier($customer_id, 'cus', 'customer');
+		return $this->execute('customers.retrieve', [$customer_id], $this->options());
+	}
+
+	/**
+	 * Deletes an account-owned Customer and returns only deletion evidence.
+	 *
+	 * Stripe owns replay semantics for the supplied idempotency key. This
+	 * boundary deliberately neither caches nor manufactures a successful
+	 * deletion when the provider response cannot prove it.
+	 *
+	 * @return array{id:string,deleted:true}
+	 */
+	public function delete_customer(string $id, string $idempotency_key): array {
+		self::require_identifier($id, 'cus', 'customer');
+		$response=$this->execute('customers.delete', [$id], $this->required_idempotency_options($idempotency_key));
+		$resource=self::cleanup_resource($response);
+		self::require_cleanup_identifier($resource, $id, 'cus', 'customer');
+		if(($resource['deleted'] ?? null)!==true){
+			throw self::invalid_cleanup_response();
+		}
+		return ['id'=>$id, 'deleted'=>true];
+	}
+
+	/** @param array<string, mixed> $params */
+	public function create_setup_intent(array $params, string $idempotency=''): mixed {
+		if(!array_key_exists('usage', $params)){
+			$params['usage']='off_session';
+		}
+		return $this->execute('setup_intents.create', [$params], $this->options($idempotency));
+	}
+
+	public function retrieve_setup_intent(string $setup_intent_id): mixed {
+		self::require_identifier($setup_intent_id, 'seti', 'setup intent');
+		return $this->execute('setup_intents.retrieve', [$setup_intent_id], $this->options());
+	}
+
+	/**
+	 * Cancels an account-owned SetupIntent and projects a non-secret result.
+	 *
+	 * @param array<string, mixed> $params
+	 * @return array{id:string,status:string,customer:?string,payment_method:?string,cancellation_reason:?string}
+	 */
+	public function cancel_setup_intent(string $id, array $params, string $idempotency_key): array {
+		self::require_identifier($id, 'seti', 'setup intent');
+		$params=self::normalize_setup_intent_cancel_params($params);
+		$response=$this->execute('setup_intents.cancel', [$id, $params], $this->required_idempotency_options($idempotency_key));
+		$resource=self::cleanup_resource($response);
+		self::require_cleanup_identifier($resource, $id, 'seti', 'setup intent');
+		if(($resource['status'] ?? null)!=='canceled'){
+			throw self::invalid_cleanup_response();
+		}
+		$reason=$resource['cancellation_reason'] ?? null;
+		if($reason!==null && (!is_string($reason) || !in_array($reason, ['abandoned', 'requested_by_customer', 'duplicate'], true))){
+			throw self::invalid_cleanup_response();
+		}
+		$expected_reason=$params['cancellation_reason'] ?? null;
+		if($expected_reason!==null && (!is_string($reason) || !hash_equals($expected_reason, $reason))){
+			throw self::invalid_cleanup_response();
+		}
+		return [
+			'id'=>$id,
+			'status'=>'canceled',
+			'customer'=>self::cleanup_reference($resource['customer'] ?? null, 'cus', 'customer'),
+			'payment_method'=>self::cleanup_reference($resource['payment_method'] ?? null, 'pm', 'payment method'),
+			'cancellation_reason'=>$reason,
+		];
+	}
+
+	public function retrieve_payment_method(string $payment_method_id): mixed {
+		self::require_identifier($payment_method_id, 'pm', 'payment method');
+		return $this->execute('payment_methods.retrieve', [$payment_method_id], $this->options());
+	}
+
+	/** @return array{id:string,customer:null} */
+	public function detach_payment_method(string $id, string $idempotency_key): array {
+		self::require_identifier($id, 'pm', 'payment method');
+		$response=$this->execute('payment_methods.detach', [$id], $this->required_idempotency_options($idempotency_key));
+		$resource=self::cleanup_resource($response);
+		self::require_cleanup_identifier($resource, $id, 'pm', 'payment method');
+		if(!array_key_exists('customer', $resource) || ($resource['customer']!==null && $resource['customer']!=='')){
+			throw self::invalid_cleanup_response();
+		}
+		return ['id'=>$id, 'customer'=>null];
+	}
+
+	/**
+	 * Creates and confirms an off-session PaymentIntent.
+	 *
+	 * @param array<string, mixed> $params
+	 */
+	public function create_payment_intent(array $params, string $idempotency=''): mixed {
+		if(array_key_exists('off_session', $params) && $params['off_session']!==true){
+			throw new \InvalidArgumentException('Stripe account PaymentIntents must be off-session.');
+		}
+		if(array_key_exists('confirm', $params) && $params['confirm']!==true){
+			throw new \InvalidArgumentException('Stripe account off-session PaymentIntents must be confirmed.');
+		}
+		$params['off_session']=true;
+		$params['confirm']=true;
+		return $this->execute('payment_intents.create', [$params], $this->options($idempotency));
+	}
+
+	public function retrieve_payment_intent(string $payment_intent_id): mixed {
+		self::require_identifier($payment_intent_id, 'pi', 'payment intent');
+		return $this->execute('payment_intents.retrieve', [$payment_intent_id], $this->options());
+	}
+
+	/**
+	 * Verifies and constructs a Stripe event locally; no network request occurs.
+	 */
+	public function construct_webhook_event(string $payload, string $signature, string $webhook_secret): mixed {
+		if($payload===''){
+			throw new \InvalidArgumentException('Stripe webhook payload is missing.');
+		}
+		if(preg_match('/^whsec_[A-Za-z0-9]{16,}$/D', trim($webhook_secret))!==1){
+			throw new \InvalidArgumentException('Stripe webhook secret is missing or invalid.');
+		}
+		$signature=trim($signature);
+		if(
+			preg_match('/(?:^|,)t=\d+(?:,|$)/', $signature)!==1
+			|| preg_match('/(?:^|,)v1=[a-f0-9]{64}(?:,|$)/i', $signature)!==1
+		){
+			throw new \InvalidArgumentException('Stripe webhook signature is missing or invalid.');
+		}
+		if($this->executor!==null){
+			return ($this->executor)('webhooks.construct_event', [$payload, $signature, trim($webhook_secret)], []);
+		}
+		self::load_sdk('\Stripe\Webhook');
+		return \Stripe\Webhook::constructEvent($payload, $signature, trim($webhook_secret));
+	}
+
+	/**
+	 * @param array<int, mixed> $arguments
+	 * @param array<string, mixed> $options
+	 */
+	private function execute(string $operation, array $arguments, array $options): mixed {
+		if($this->executor!==null){
+			return ($this->executor)($operation, $arguments, $options);
+		}
+		return $this->execute_with_client($operation, $arguments, $options);
+	}
+
+	/**
+	 * @param array<int, mixed> $arguments
+	 * @param array<string, mixed> $options
+	 */
+	private function execute_with_client(string $operation, array $arguments, array $options): mixed {
+		[$service_name, $method]=match($operation){
+			'customers.create'=>['customers', 'create'],
+			'customers.update'=>['customers', 'update'],
+			'customers.retrieve'=>['customers', 'retrieve'],
+			'customers.delete'=>['customers', 'delete'],
+			'setup_intents.create'=>['setupIntents', 'create'],
+			'setup_intents.retrieve'=>['setupIntents', 'retrieve'],
+			'setup_intents.cancel'=>['setupIntents', 'cancel'],
+			'payment_methods.retrieve'=>['paymentMethods', 'retrieve'],
+			'payment_methods.detach'=>['paymentMethods', 'detach'],
+			'payment_intents.create'=>['paymentIntents', 'create'],
+			'payment_intents.retrieve'=>['paymentIntents', 'retrieve'],
+			default=>throw new \LogicException('Unsupported Stripe account operation.'),
+		};
+		$client=$this->stripe_client();
+		if(property_exists($client, $service_name)){
+			$service=$client->{$service_name};
+		}
+		elseif(method_exists($client, 'getService')){
+			$service=$client->getService($service_name);
+		}
+		else
+		{
+			throw new \RuntimeException('Stripe account client service is unavailable.');
+		}
+		if(!is_object($service) || !is_callable([$service, $method])){
+			throw new \RuntimeException('Stripe account client operation is unavailable.');
+		}
+		if(in_array($method, ['retrieve', 'delete', 'detach'], true)){
+			return $service->{$method}($arguments[0], [], $options);
+		}
+		if(in_array($method, ['update', 'cancel'], true)){
+			return $service->{$method}($arguments[0], $arguments[1], $options);
+		}
+		return $service->{$method}($arguments[0], $options);
+	}
+
+	private function stripe_client(): object {
+		if($this->client!==null){
+			return $this->client;
+		}
+		self::load_sdk('\Stripe\StripeClient');
+		$this->client=new \Stripe\StripeClient($this->secret_key);
+		return $this->client;
+	}
+
+	private static function load_sdk(string $required_class, ?string $bootstrap=null): void {
+		if(class_exists($required_class, false)){
+			return;
+		}
+		$bootstrap=$bootstrap ?? dirname(__DIR__).'/src/init.php';
+		if(!is_file($bootstrap)){
+			throw new \RuntimeException('Stripe SDK bootstrap is unavailable.');
+		}
+		require_once $bootstrap;
+		if(!class_exists($required_class, false)){
+			throw new \RuntimeException('Required Stripe SDK component is unavailable.');
+		}
+	}
+
+	/** @return array<string, mixed> */
+	private function options(string $idempotency=''): array {
+		$options=$this->request_options;
+		if($idempotency===''){
+			return $options;
+		}
+		$options['idempotency_key']=self::normalize_idempotency($idempotency);
+		return $options;
+	}
+
+	/** @return array<string, mixed> */
+	private function required_idempotency_options(string $idempotency_key): array {
+		$options=$this->request_options;
+		$options['idempotency_key']=self::normalize_idempotency($idempotency_key);
+		return $options;
+	}
+
+	/**
+	 * @param array<string, mixed> $options
+	 * @return array<string, mixed>
+	 */
+	private static function normalize_request_options(array $options): array {
+		$allowed=['idempotency_key'=>true, 'stripe_account'=>true, 'stripe_version'=>true];
+		foreach($options as $key=>$value){
+			if(!is_string($key) || !isset($allowed[$key])){
+				throw new \InvalidArgumentException('Unsupported Stripe account request option.');
+			}
+			if($key==='idempotency_key'){
+				if(!is_string($value)){
+					throw new \InvalidArgumentException('Stripe idempotency key must be a string.');
+				}
+				$options[$key]=self::normalize_idempotency($value);
+			}
+			elseif($key==='stripe_account'){
+				if(!is_string($value) || strlen($value)>255 || preg_match('/^acct_[A-Za-z0-9]{8,}$/D', $value)!==1){
+					throw new \InvalidArgumentException('Stripe connected account request option is invalid.');
+				}
+			}
+			elseif(!is_string($value) || $value==='' || strlen($value)>128 || preg_match('/[\x00-\x1F\x7F]/', $value)===1){
+				throw new \InvalidArgumentException('Stripe version request option is invalid.');
+			}
+		}
+		return $options;
+	}
+
+	private static function normalize_idempotency(string $idempotency): string {
+		if(
+			$idempotency==='' || strlen($idempotency)>255
+			|| trim($idempotency)!==$idempotency
+			|| preg_match('/[\x00-\x1F\x7F]/', $idempotency)===1
+		){
+			throw new \InvalidArgumentException('Stripe idempotency key is invalid.');
+		}
+		return $idempotency;
+	}
+
+	private static function require_identifier(string $identifier, string $prefix, string $label): void {
+		if(strlen($identifier)>255 || preg_match('/^'.preg_quote($prefix, '/').'_[A-Za-z0-9]{6,}$/D', $identifier)!==1){
+			throw new \InvalidArgumentException('Stripe '.$label.' identifier is invalid.');
+		}
+	}
+
+	/** @param array<string, mixed> $params @return array<string, string> */
+	private static function normalize_setup_intent_cancel_params(array $params): array {
+		foreach($params as $key=>$value){
+			if($key!=='cancellation_reason'){
+				throw new \InvalidArgumentException('Unsupported Stripe SetupIntent cancellation parameter.');
+			}
+			if(!is_string($value) || !in_array($value, ['abandoned', 'requested_by_customer', 'duplicate'], true)){
+				throw new \InvalidArgumentException('Stripe SetupIntent cancellation reason is invalid.');
+			}
+		}
+		return $params;
+	}
+
+	/** @return array<string, mixed> */
+	private static function cleanup_resource(mixed $resource): array {
+		if(is_array($resource)){
+			return $resource;
+		}
+		if(!is_object($resource)){
+			throw self::invalid_cleanup_response();
+		}
+		if(method_exists($resource, 'toArray')){
+			try{
+				$resource=$resource->toArray();
+			}catch(\Throwable){
+				throw self::invalid_cleanup_response();
+			}
+			if(!is_array($resource)){
+				throw self::invalid_cleanup_response();
+			}
+			return $resource;
+		}
+		return get_object_vars($resource);
+	}
+
+	/** @param array<string, mixed> $resource */
+	private static function require_cleanup_identifier(
+		array $resource,
+		string $expected,
+		string $prefix,
+		string $label,
+	): void {
+		$actual=$resource['id'] ?? null;
+		if(!is_string($actual)){
+			throw self::invalid_cleanup_response();
+		}
+		try{
+			self::require_identifier($actual, $prefix, $label);
+		}catch(\InvalidArgumentException){
+			throw self::invalid_cleanup_response();
+		}
+		if(!hash_equals($expected, $actual)){
+			throw self::invalid_cleanup_response();
+		}
+	}
+
+	private static function cleanup_reference(mixed $reference, string $prefix, string $label): ?string {
+		if($reference===null || $reference===''){
+			return null;
+		}
+		if(is_array($reference) || is_object($reference)){
+			$reference=self::cleanup_resource($reference)['id'] ?? null;
+		}
+		if(!is_string($reference)){
+			throw self::invalid_cleanup_response();
+		}
+		try{
+			self::require_identifier($reference, $prefix, $label);
+		}catch(\InvalidArgumentException){
+			throw self::invalid_cleanup_response();
+		}
+		return $reference;
+	}
+
+	private static function invalid_cleanup_response(): \RuntimeException {
+		return new \RuntimeException('Stripe account cleanup response is invalid.');
+	}
+
+	/** @return array{mode:string,key_type:string}|null */
+	private static function key_metadata(string $secret_key): ?array {
+		$secret_key=trim($secret_key);
+		if(preg_match('/^(sk|rk)_(test|live)_[A-Za-z0-9]{16,}$/D', $secret_key, $matches)!==1){
+			return null;
+		}
+		return [
+			'mode'=>$matches[2],
+			'key_type'=>$matches[1]==='rk' ? 'restricted' : 'secret',
+		];
+	}
+}

--- a/runtime/modules/stripe/kernel/stripe.main.php
+++ b/runtime/modules/stripe/kernel/stripe.main.php
@@ -2,763 +2,594 @@
 /*************************************************************************
  * Dataphyre
  *
- * Copyright (c) 2025 Shopiro Ltd.
+ * Copyright (c) 2026 Shopiro Ltd.
  * SPDX-License-Identifier: MIT
  */
+declare(strict_types=1);
+
 namespace dataphyre;
 
-tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T="Module initialization");
-
-dp_define_module_config('stripe', 'DP_STRIPE_CFG', [
-	'test_mode'=>false,
-	'webhook_secret_key'=>false,
-	'api_secret_key_live'=>false,
-	'api_publishable_key_live'=>false,
-	'api_secret_key_test_mode'=>false,
-	'api_publishable_key_test_mode'=>false,
-	'payment_intent_minimum_amount'=>[],
-]);
-if(function_exists('sql_define_table')){
-	sql_define_table('stripe_payment_methods', __DIR__.'/stripe.tables.php', 'payment_methods');
-}
+require_once __DIR__.'/stripe.account_client.php';
 
 /**
- * Kernel Stripe facade for Dataphyre payments, Connect accounts, and stored cards.
+ * Stripe's compatibility facade backed by explicit SDK, SQL, and HTTP boundaries.
  *
- * This wrapper owns the runtime boundary between Dataphyre configuration, the
- * bundled Stripe SDK, SQL-backed local payment-method metadata, and project-level
- * webhook callbacks. Methods return Stripe SDK resources on success, string
- * failure markers for selected business branches, or false when the Stripe layer
- * cannot be loaded or the SDK raises an exception.
+ * Public method names remain stable for existing applications. Repeated SDK
+ * dispatch and exception policy live in one gateway, making every operation
+ * deterministic under tests while preserving the bundled SDK in production.
  */
 class stripe {
+	/** @var array<string,mixed> */
+	private static array $runtime=[];
+
+	/** @var array<string,array{0:class-string,1:string}> */
+	private const SDK_OPERATIONS=[
+		'balance.retrieve'=>[\Stripe\Balance::class, 'retrieve'],
+		'customer.create'=>[\Stripe\Customer::class, 'create'],
+		'account.create'=>[\Stripe\Account::class, 'create'],
+		'account.retrieve'=>[\Stripe\Account::class, 'retrieve'],
+		'account.update'=>[\Stripe\Account::class, 'update'],
+		'account.create_external_account'=>[\Stripe\Account::class, 'createExternalAccount'],
+		'payment_intent.create'=>[\Stripe\PaymentIntent::class, 'create'],
+		'payment_intent.retrieve'=>[\Stripe\PaymentIntent::class, 'retrieve'],
+		'account_link.create'=>[\Stripe\AccountLink::class, 'create'],
+		'transfer.create'=>[\Stripe\Transfer::class, 'create'],
+		'payout.create'=>[\Stripe\Payout::class, 'create'],
+		'refund.create'=>[\Stripe\Refund::class, 'create'],
+		'payment_method.retrieve'=>[\Stripe\PaymentMethod::class, 'retrieve'],
+		'payment_method.all'=>[\Stripe\PaymentMethod::class, 'all'],
+		'webhook.construct'=>[\Stripe\Webhook::class, 'constructEvent'],
+	];
+
+	/** Restores the facade and installs optional deterministic runtime boundaries. */
+	public static function resetRuntime(array $runtime=[]): void {
+		self::$runtime=$runtime;
+	}
+
+	/** Merges runtime boundaries without replacing unrelated observations. */
+	public static function configureRuntime(array $runtime): void {
+		self::$runtime=array_replace(self::$runtime, $runtime);
+	}
+
+	/** @return array<string,mixed> */
+	public static function runtimeState(): array {
+		return self::$runtime;
+	}
 
 	private static function cfg(string $key, mixed $default=false): mixed {
+		if(is_array(self::$runtime['config'] ?? null) && array_key_exists($key, self::$runtime['config'])){
+			return self::$runtime['config'][$key];
+		}
 		if(defined('RUN_MODE') && RUN_MODE==='diagnostic' && is_array($GLOBALS['DP_STRIPE_CFG_OVERRIDE'] ?? null) && array_key_exists($key, $GLOBALS['DP_STRIPE_CFG_OVERRIDE'])){
 			return $GLOBALS['DP_STRIPE_CFG_OVERRIDE'][$key];
 		}
-		return DP_STRIPE_CFG[$key] ?? $default;
+		return defined('DP_STRIPE_CFG') && is_array(DP_STRIPE_CFG)
+			? (DP_STRIPE_CFG[$key] ?? $default)
+			: $default;
 	}
 
-	/**
-	 * Resolves whether the Stripe wrapper should use test-mode credentials.
-	 *
-	 * A hard override constant wins over module configuration so tests and CLI
-	 * jobs can force test mode without mutating deployed configuration.
-	 *
-	 * @return bool True when Stripe test credentials should be selected.
-	 */
 	private static function test_mode(): bool {
-		if(defined('DP_STRIPE_TEST_MODE_OVERRIDE') && DP_STRIPE_TEST_MODE_OVERRIDE===true){
-			return true;
-		}
-		return self::cfg('test_mode', false)===true;
+		$override=self::$runtime['test_mode_override']
+			?? (defined('DP_STRIPE_TEST_MODE_OVERRIDE') ? DP_STRIPE_TEST_MODE_OVERRIDE : null);
+		return $override===true || self::cfg('test_mode', false)===true;
 	}
 
-	/**
-	 * Returns the active platform API key from the Stripe SDK.
-	 *
-	 * The SDK is loaded first so callers see the same configured key that outgoing
-	 * Stripe requests will use.
-	 *
-	 * @return string|false Active Stripe API key, or false when the SDK cannot be loaded.
-	 */
-	public static function get_platform_account(){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()){
-			return \Stripe\Stripe::$api_key;
-		}
-		return false;
+	public static function get_platform_account(): string|false {
+		self::trace(__FUNCTION__);
+		return self::load_stripe() ? self::readApiKey() : false;
 	}
 
-	/**
-	 * Applies the configured platform secret key to the Stripe SDK.
-	 *
-	 * This is the platform-account bootstrap path used before account, payment,
-	 * transfer, payout, and webhook operations.
-	 *
-	 * @return bool True when the SDK accepted the configured platform key.
-	 */
-	public static function set_platform_account(){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()){
-			\Stripe\Stripe::$api_key=self::get_secret_key();
-			return true;
+	public static function set_platform_account(): bool {
+		self::trace(__FUNCTION__);
+		if(!self::load_stripe()){
+			return false;
 		}
-		return false;
+		$key=self::get_secret_key();
+		if(!is_string($key) || trim($key)===''){
+			self::unavailable('DataphyreStripe: Platform API secret is not configured.');
+			return false;
+		}
+		self::writeApiKey($key);
+		return true;
 	}
 
-	/**
-	 * Selects the publishable Stripe key for the current runtime mode.
-	 *
-	 * @return string|false Live or test publishable key, or false when unconfigured.
-	 */
-	public static function get_publishable_key() : string|bool {
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::test_mode()!==true){
-			return self::cfg('api_publishable_key_live', false);
-		}
-		return self::cfg('api_publishable_key_test_mode', false);
+	public static function get_publishable_key(): string|bool {
+		self::trace(__FUNCTION__);
+		return self::test_mode()
+			? self::cfg('api_publishable_key_test_mode', false)
+			: self::cfg('api_publishable_key_live', false);
 	}
 
-	/**
-	 * Returns the webhook signing secret used to authenticate incoming events.
-	 *
-	 * @return string|false Webhook secret, or false when unconfigured.
-	 */
-	public static function get_webhook_secret_key() : string|bool {
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
+	public static function get_webhook_secret_key(): string|bool {
+		self::trace(__FUNCTION__);
 		return self::cfg('webhook_secret_key', false);
 	}
 
-	/**
-	 * Selects the secret Stripe key for the current runtime mode.
-	 *
-	 * @return string|false Live or test secret key, or false when unconfigured.
-	 */
-	public static function get_secret_key() : string|bool {
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::test_mode()!==true){
-			return self::cfg('api_secret_key_live', false);
-		}
-		return self::cfg('api_secret_key_test_mode', false);
+	public static function get_secret_key(): string|bool {
+		self::trace(__FUNCTION__);
+		return self::test_mode()
+			? self::cfg('api_secret_key_test_mode', false)
+			: self::cfg('api_secret_key_live', false);
 	}
 
-	/**
-	 * Loads and configures the bundled Stripe SDK.
-	 *
-	 * A CALL_STRIPE_LOAD dialback may short-circuit SDK loading for tests or custom
-	 * bootstraps. Normal loading requires the bundled SDK, sets the selected secret
-	 * key, and enables network retries. Missing SDK or key state escalates through
-	 * core::unavailable() because payment operations must fail closed.
-	 *
-	 * @return bool True when the Stripe SDK is available for calls.
-	 */
-	public static function load_stripe() : bool {
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(null!==$early_return=core::dialback("CALL_STRIPE_LOAD",...func_get_args())) return $early_return;
-		if(!class_exists("\Stripe\Stripe")){
-			try{
-				require_once(dirname(__DIR__)."/src/init.php");
-			}catch(\Exception $e){
-				core::unavailable(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $D='DataphyreStripe: Unable to load stripe library. Server\'s data is like corrupted.', 'safemode');
+	/** Loads the bundled SDK or delegates loading to the configured runtime seam. */
+	public static function load_stripe(): bool {
+		self::trace(__FUNCTION__);
+		if(array_key_exists('load', self::$runtime)){
+			$load=self::$runtime['load'];
+			if(!is_callable($load)){
+				throw new \LogicException('Stripe loader boundary must be callable.');
 			}
-			\Stripe\Stripe::$api_key=self::get_secret_key();
-			\Stripe\Stripe::setMaxNetworkRetries(3);
+			return $load()===true;
 		}
-		else
-		{
-			if(empty(\Stripe\Stripe::$api_key)){
-				core::unavailable(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $D='DataphyreStripe: Stripe API key not set.', 'safemode');
+		$dialback=self::$runtime['dialback'] ?? (class_exists(core::class, false) ? [core::class, 'dialback'] : null);
+		if(is_callable($dialback)){
+			$early=$dialback('CALL_STRIPE_LOAD');
+			if($early!==null){
+				return $early===true;
 			}
+		}
+		try{
+			if(!class_exists(\Stripe\Stripe::class)){
+				$loader=self::$runtime['sdk_loader'] ?? static function(): void {
+					require_once dirname(__DIR__).'/src/init.php';
+				};
+				if(!is_callable($loader)){
+					throw new \LogicException('Stripe SDK loader boundary must be callable.');
+				}
+				$loader();
+			}
+			if(!class_exists(\Stripe\Stripe::class, false)){
+				self::unavailable('DataphyreStripe: Unable to load the Stripe SDK.');
+				return false;
+			}
+			$key=self::get_secret_key();
+			if(!is_string($key) || trim($key)===''){
+				self::unavailable('DataphyreStripe: Stripe API key is not configured.');
+				return false;
+			}
+			self::writeApiKey($key);
+			$retries=self::$runtime['set_network_retries'] ?? [\Stripe\Stripe::class, 'setMaxNetworkRetries'];
+			if(!is_callable($retries)){
+				throw new \LogicException('Stripe retry boundary must be callable.');
+			}
+			$retries(3);
+			return true;
+		}catch(\Throwable $exception){
+			self::unavailable('DataphyreStripe: Unable to initialize the Stripe SDK.', $exception);
+			return false;
+		}
+	}
+
+	/** Verifies and dispatches an incoming Stripe webhook without direct process exits. */
+	public static function handle_webhook(array $runtime=[]): mixed {
+		self::trace(__FUNCTION__);
+		if(!self::set_platform_account()){
+			return false;
+		}
+		$server=is_array($runtime['server'] ?? null)
+			? $runtime['server']
+			: (is_array(self::$runtime['server'] ?? null) ? self::$runtime['server'] : $_SERVER);
+		$signature=(string)($server['HTTP_STRIPE_SIGNATURE'] ?? '');
+		$payload=$runtime['payload'] ?? self::$runtime['payload'] ?? null;
+		if(is_callable($payload)){
+			$payload=$payload();
+		}
+		if(!is_string($payload)){
+			$payload=(string)file_get_contents('php://input');
+		}
+		$secret=self::get_webhook_secret_key();
+		try{
+			$verifier=$runtime['verify'] ?? self::$runtime['verify_webhook'] ?? self::operationCallable('webhook.construct');
+			if(!is_callable($verifier)){
+				throw new \LogicException('Stripe webhook verifier must be callable.');
+			}
+			$event=$verifier($payload, $signature, $secret);
+		}catch(\Throwable $exception){
+			self::emitWebhook(400, 'Webhook Error: '.$exception->getMessage(), $runtime);
+			return false;
+		}
+		$type=is_object($event) ? (string)($event->type ?? '') : (string)($event['type'] ?? '');
+		$object=is_object($event)
+			? ($event->data->object ?? null)
+			: ($event['data']['object'] ?? null);
+		$callbackName='stripe_webhook_'.str_replace('.', '_', $type);
+		$callbacks=is_array($runtime['callbacks'] ?? null)
+			? $runtime['callbacks']
+			: (is_array(self::$runtime['webhook_callbacks'] ?? null) ? self::$runtime['webhook_callbacks'] : []);
+		$callback=$callbacks[$callbackName] ?? (function_exists($callbackName) ? $callbackName : null);
+		if(!is_callable($callback)){
+			self::emitWebhook(400, 'Unsupported webhook event type: '.$type, $runtime);
+			return false;
+		}
+		return $callback($object);
+	}
+
+	public static function get_platform_balance(): mixed {
+		return self::remote(__FUNCTION__, 'balance.retrieve');
+	}
+
+	public static function handle_new_payment_method(string $stripe_token, int $userid, string $stripe_customer_id, string $name_on_card, ?callable $no_customer_account_callback=null): bool|string {
+		self::trace(__FUNCTION__, func_get_args());
+		if(!self::load_stripe()){
+			return false;
+		}
+		if(self::sql('select', 'id', 'stripe_payment_methods', 'WHERE id=?', [$stripe_token])!==false){
+			return false;
+		}
+		$paymentMethod=self::retrieve_payment_method($stripe_token);
+		if($paymentMethod===false){
+			return 'bad_token';
+		}
+		if($stripe_customer_id==='' && is_callable($no_customer_account_callback)){
+			$stripe_customer_id=$no_customer_account_callback($userid, $paymentMethod);
+			if($stripe_customer_id===false){
+				return 'failed_customer_creation_callback';
+			}
+		}
+		$insert=self::sql('insert', 'stripe_payment_methods', [
+			'id'=>$paymentMethod->id,
+			'brand'=>$paymentMethod->card->brand,
+			'type'=>$paymentMethod->type,
+			'userid'=>$userid,
+			'is_attached'=>false,
+			'is_main'=>false,
+			'country'=>$paymentMethod->card->country,
+			'last_four_digits'=>$paymentMethod->card->last4,
+			'postal_code'=>$paymentMethod->billing_details->address->postal_code,
+			'expiration_month'=>$paymentMethod->card->exp_month,
+			'expiration_year'=>$paymentMethod->card->exp_year,
+			'name_on_card'=>$name_on_card,
+		]);
+		if($insert===false){
+			return 'failed_creating_method';
+		}
+		$result=self::attach_payment_method($stripe_token, (string)$stripe_customer_id);
+		if($result===false || is_string($result)){
+			self::deleteLocalPaymentMethod($stripe_token);
+			return $result;
+		}
+		if(($result->customer ?? null)!==null && self::sql('update', 'stripe_payment_methods', [
+			'mysql'=>'is_attached=1',
+			'postgresql'=>'is_attached=true',
+		], 'WHERE id=?', [$paymentMethod->id], true)===false){
+			self::deleteLocalPaymentMethod($stripe_token);
+			return 'failed_attaching';
 		}
 		return true;
 	}
 
-	/**
-	 * Authenticates and dispatches an incoming Stripe webhook.
-	 *
-	 * The raw request body and Stripe signature header are verified with the
-	 * configured webhook secret. Supported events are delegated to a project
-	 * function named `stripe_webhook_{event_type}` with dots converted to
-	 * underscores. Invalid signatures and unsupported events emit HTTP 400.
-	 *
-	 * @return mixed Callback result, false when platform setup fails, or void after emitting an HTTP response.
-	 */
-	public static function handle_webhook(){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::set_platform_account()){
-			if(self::load_stripe()===true){
-				$signature=$_SERVER['HTTP_STRIPE_SIGNATURE'];
-				$payload=file_get_contents('php://input');
-				$webhook_secret_key=self::get_webhook_secret_key();
-				try{
-					$event=\Stripe\Webhook::constructEvent($payload,$signature,$webhook_secret_key);
-				}catch(\Exception $e){
-					http_response_code(400);
-					echo 'Webhook Error: '.$e->getMessage();
-					return;
-				}
-				$event_type=$event->type;
-				$function_name='stripe_webhook_'.str_replace('.', '_', $event_type);
-				if(function_exists($function_name)){
-					return call_user_func($function_name, $event->data->object);
-				}
-				else
-				{
-					http_response_code(400);
-					echo 'Unsupported webhook event type: '.$event_type;
-					return;
-				}
-				http_response_code(200);
-				echo 'Webhook Event Processed';
-				exit();
-			}
-		}
-		return false;
+	public static function create_customer(int $userid, string $email, string $name): mixed {
+		return self::remote(__FUNCTION__, 'customer.create', [[
+			'email'=>$email,
+			'name'=>$name,
+			'metadata'=>['user_id'=>$userid],
+		]]);
 	}
 
-	/**
-	 * Retrieves the Stripe platform balance.
-	 *
-	 * @return \Stripe\Balance|false Stripe balance resource, or false on load/API failure.
-	 */
-	public static function get_platform_balance(){
-		tracelog( __FILE__, __LINE__, __CLASS__, __FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$balance=\Stripe\Balance::retrieve();
-				return $balance;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
+	public static function create_account(array $params): mixed {
+		return self::remote(__FUNCTION__, 'account.create', [$params]);
 	}
 
-	/**
-	 * Persists and attaches a newly supplied Stripe payment method.
-	 *
-	 * The token is first checked against the local payment-method table to avoid
-	 * duplicate inserts. A missing customer id may be created by callback. Local SQL
-	 * metadata is rolled back when attachment or attached-state persistence fails.
-	 *
-	 * @param string $stripe_token Stripe PaymentMethod id from the client.
-	 * @param int $userid Dataphyre user id owning the method.
-	 * @param string $stripe_customer_id Stripe Customer id to attach to.
-	 * @param string $name_on_card Cardholder name stored locally.
-	 * @param callable|null $no_customer_account_callback Callback that can create a customer id.
-	 * @return bool|string False on load failure, true on success, or a business failure marker.
-	 */
-	public static function handle_new_payment_method(string $stripe_token, int $userid, string $stripe_customer_id, string $name_on_card, ?callable $no_customer_account_callback=null){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			if(false===sql_select(
-				$S="id",
-				$L="stripe_payment_methods",
-				$P="WHERE id=?",
-				$V=array($stripe_token)
-			)){
-				if(false===$payment_method=self::retrieve_payment_method($stripe_token)){
-					return 'bad_token';
-				}
-				if(empty($stripe_customer_id) && is_callable($no_customer_account_callback)){
-					if(false===$stripe_customer_id=$no_customer_account_callback($userid, $payment_method)){
-						return 'failed_customer_creation_callback';
-					}
-				}
-				if(false===$insertid=sql_insert(
-					$L="stripe_payment_methods",
-					$F=[
-						"id"=>$payment_method->id,
-						"brand"=>$payment_method->card->brand,
-						"type"=>$payment_method->type,
-						"userid"=>$userid,
-						"is_attached"=>false,
-						"is_main"=>false,
-						"country"=>$payment_method->card->country,
-						"last_four_digits"=>$payment_method->card->last4,
-						"postal_code"=>$payment_method->billing_details->address->postal_code,
-						"expiration_month"=>$payment_method->card->exp_month,
-						"expiration_year"=>$payment_method->card->exp_year,
-						"name_on_card"=>$name_on_card
-					]
-				)){
-					return 'failed_creating_method';
-				}
-				$result=self::attach_payment_method($stripe_token, $stripe_customer_id);
-				if($result===false || is_string($result)){
-					sql_delete(
-						$L="stripe_payment_methods",
-						$P="WHERE id=?",
-						$V=array($stripe_token),
-						$CC=true
-					);
-					return $result;
-				}
-				if($result->customer!==null){
-					if(false===sql_update(
-						$L="stripe_payment_methods",
-						$F=[
-							"mysql"=>"is_attached=1",
-							"postgresql"=>"is_attached=true"
-						],
-						$P="WHERE id=?",
-						$V=array($payment_method->id),
-						$CC=true
-					)){
-						sql_delete(
-							$L="stripe_payment_methods",
-							$P="WHERE id=?",
-							$V=array($stripe_token),
-							$CC=true
-						);
-						return 'failed_attaching';
-					}
-				}
-				return true;
-			}
-		}
-		return false;
+	public static function verify_account(string $account_id, array $params): mixed {
+		return self::remote(__FUNCTION__, 'account.update', [$account_id, $params]);
 	}
 
-	/**
-	 * Creates a Stripe Customer linked to a Dataphyre user id.
-	 *
-	 * @param int $userid Dataphyre user id stored in Stripe metadata.
-	 * @param string $email Customer email.
-	 * @param string $name Customer display name.
-	 * @return \Stripe\Customer|false Stripe customer resource, or false on load/API failure.
-	 */
-	public static function create_customer(int $userid, string $email, string $name){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$customer=\Stripe\Customer::create([
-					'email'=>$email,
-					'name'=>$name,
-					'metadata'=>['user_id'=>$userid]
-				]);
-				return $customer;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
+	public static function create_bank_account(string $account_id, array $params): mixed {
+		return self::remote(__FUNCTION__, 'account.create_external_account', [$account_id, ['external_account'=>$params]]);
 	}
 
-	/**
-	 * Creates a Stripe Connect account.
-	 *
-	 * @param array<string, mixed> $params Stripe Account creation parameters.
-	 * @return \Stripe\Account|false Stripe account resource, or false on load/API failure.
-	 */
-    public static function create_account(array $params){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$account=\Stripe\Account::create($params);
-				return $account;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
-    }
-
-	/**
-	 * Updates a Connect account with verification payload fields.
-	 *
-	 * @param string $account_id Stripe Account id.
-	 * @param array<string, mixed> $params Stripe Account update parameters.
-	 * @return \Stripe\Account|false Updated account resource, or false on load/API failure.
-	 */
-	public static function verify_account(string $account_id, array $params){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$account=\Stripe\Account::update($account_id, $params);
-				return $account;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
+	public static function set_default_for_payouts(string $account_id, string $bank_account_id): mixed {
+		return self::remote(__FUNCTION__, 'account.update', [$account_id, ['default_for_currency'=>$bank_account_id]]);
 	}
 
-	/**
-	 * Adds an external bank account to a Connect account.
-	 *
-	 * @param string $account_id Stripe Account id.
-	 * @param array<string, mixed> $params External account token or bank account parameters.
-	 * @return \Stripe\BankAccount|\Stripe\Card|false Stripe external account resource, or false on load/API failure.
-	 */
-	public static function create_bank_account(string $account_id, array $params){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$bank_account=\Stripe\Account::createExternalAccount($account_id, ['external_account' => $params]);
-				return $bank_account;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
+	public static function update_account(string $account_id, array $params): mixed {
+		return self::remote(__FUNCTION__, 'account.update', [$account_id, $params]);
 	}
 
-	/**
-	 * Marks a Connect external account as the default payout destination.
-	 *
-	 * @param string $account_id Stripe Account id.
-	 * @param string $bank_account_id External bank account id.
-	 * @return \Stripe\Account|false Updated account resource, or false on load/API failure.
-	 */
-	public static function set_default_for_payouts(string $account_id, string $bank_account_id){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$account=\Stripe\Account::update($account_id, ['default_for_currency' => $bank_account_id]);
-				return $account;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
+	public static function create_payment_intent(array $params): mixed {
+		return self::remote(__FUNCTION__, 'payment_intent.create', [$params]);
 	}
 
-	/**
-	 * Updates a Stripe Connect account with arbitrary account parameters.
-	 *
-	 * @param string $account_id Stripe Account id.
-	 * @param array<string, mixed> $params Stripe Account update parameters.
-	 * @return \Stripe\Account|false Updated account resource, or false on load/API failure.
-	 */
-	public static function update_account(string $account_id, array $params){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$account=\Stripe\Account::update($account_id, $params);
-				return $account;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
+	public static function check_payment_status(string $payment_intent_id): string|false {
+		$intent=self::remote(__FUNCTION__, 'payment_intent.retrieve', [$payment_intent_id]);
+		return is_object($intent) && isset($intent->status) ? (string)$intent->status : false;
 	}
 
-	/**
-	 * Creates a Stripe PaymentIntent.
-	 *
-	 * @param array<string, mixed> $params Stripe PaymentIntent creation parameters.
-	 * @return \Stripe\PaymentIntent|false PaymentIntent resource, or false on load/API failure.
-	 */
-    public static function create_payment_intent(array $params){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$payment_intent=\Stripe\PaymentIntent::create($params);
-				return $payment_intent;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
-    }
-
-	/**
-	 * Retrieves the current status for a Stripe PaymentIntent.
-	 *
-	 * @param string $payment_intent_id Stripe PaymentIntent id.
-	 * @return string|false PaymentIntent status, or false on load/API failure.
-	 */
-	public static function check_payment_status(string $payment_intent_id){
-		tracelog( __FILE__, __LINE__, __CLASS__, __FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$payment_intent=\Stripe\PaymentIntent::retrieve($payment_intent_id);
-				return $payment_intent->status;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
+	public static function cancel_payment(string $payment_intentId): mixed {
+		return self::resourceAction(__FUNCTION__, 'payment_intent.retrieve', $payment_intentId, 'cancel');
 	}
 
-	/**
-	 * Cancels a Stripe PaymentIntent.
-	 *
-	 * @param string $payment_intentId Stripe PaymentIntent id.
-	 * @return \Stripe\PaymentIntent|false Cancelled PaymentIntent resource, or false on load/API failure.
-	 */
-	public static function cancel_payment(string $payment_intentId){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$payment_intent=\Stripe\PaymentIntent::retrieve($payment_intentId);
-				$payment_intent->cancel();
-				return $payment_intent;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
+	public static function create_account_link(string $account_id, string $return_url, string $refresh_url): mixed {
+		return self::remote(__FUNCTION__, 'account_link.create', [[
+			'account'=>$account_id,
+			'refresh_url'=>$refresh_url,
+			'return_url'=>$return_url,
+			'type'=>'account_onboarding',
+		]]);
 	}
 
-	/**
-	 * Creates an onboarding account link for a Connect account.
-	 *
-	 * @param string $account_id Stripe Account id.
-	 * @param string $return_url URL Stripe redirects to after onboarding.
-	 * @param string $refresh_url URL Stripe redirects to when the link expires.
-	 * @return \Stripe\AccountLink|false AccountLink resource, or false on load/API failure.
-	 */
-	public static function create_account_link(string $account_id, string $return_url, string $refresh_url){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$account_link=\Stripe\AccountLink::create([
-				  'account'=>$account_id,
-				  'refresh_url'=>$refresh_url,
-				  'return_url'=>$return_url,
-				  'type'=>'account_onboarding',
-				]);
-				return $account_link;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
+	public static function check_account_status(string $account_id): mixed {
+		return self::remote(__FUNCTION__, 'account.retrieve', [$account_id]);
 	}
 
-	/**
-	 * Retrieves a Stripe Connect account for status inspection.
-	 *
-	 * @param string $account_id Stripe Account id.
-	 * @return \Stripe\Account|false Account resource, or false on load/API failure.
-	 */
-	public static function check_account_status(string $account_id){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$account = \Stripe\Account::retrieve($account_id);
-				return $account;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
+	public static function initiate_transfer(array $params): mixed {
+		return self::remote(__FUNCTION__, 'transfer.create', [$params]);
 	}
 
-	/**
-	 * Creates a Stripe transfer from the platform balance.
-	 *
-	 * @param array<string, mixed> $params Stripe Transfer creation parameters.
-	 * @return \Stripe\Transfer|false Transfer resource, or false on load/API failure.
-	 */
-	public static function initiate_transfer(array $params){
-		tracelog( __FILE__, __LINE__, __CLASS__, __FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$transfer=\Stripe\Transfer::create($params);
-				return $transfer;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
+	public static function create_payout(array $params, array $options=[]): mixed {
+		return self::remote(__FUNCTION__, 'payout.create', [$params, $options]);
 	}
 
-	/**
-	 * Creates a Stripe payout.
-	 *
-	 * @param array<string, mixed> $params Stripe Payout creation parameters.
-	 * @param array<string, mixed> $options Stripe request options, such as connected account context.
-	 * @return \Stripe\Payout|false Payout resource, or false on load/API failure.
-	 */
-	public static function create_payout(array $params, $options=[]){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$payout=\Stripe\Payout::create($params, $options);
-				return $payout;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
+	public static function submit_payment(string $payment_intentId): mixed {
+		return self::resourceAction(__FUNCTION__, 'payment_intent.retrieve', $payment_intentId, 'confirm');
 	}
 
-	/**
-	 * Confirms a Stripe PaymentIntent.
-	 *
-	 * @param string $payment_intentId Stripe PaymentIntent id.
-	 * @return \Stripe\PaymentIntent|false Confirmed PaymentIntent resource, or false on load/API failure.
-	 */
-	public static function submit_payment(string $payment_intentId){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$payment_intent=\Stripe\PaymentIntent::retrieve($payment_intentId);
-				$payment_intent->confirm();
-				return $payment_intent;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
+	public static function submit_refund(
+		string $payment_intent_id,
+		int $amount_to_refund,
+		array $request_options=[]
+	): mixed {
+		self::trace(__FUNCTION__, func_get_args());
+		if(!self::load_stripe()){
+			return false;
 		}
-		return false;
-	}
-
-	/**
-	 * Refunds part of a PaymentIntent's first charge after local limit checking.
-	 *
-	 * The wrapper compares the requested amount against Stripe's original and
-	 * already-refunded charge amounts before creating the refund, preventing an
-	 * over-refund call from leaving Dataphyre.
-	 *
-	 * @param string $payment_intent_id Stripe PaymentIntent id.
-	 * @param int $amount_to_refund Amount in the smallest currency unit.
-	 * @return \Stripe\Refund|false Refund resource, or false on validation/load/API failure.
-	 */
-	public static function submit_refund(string $payment_intent_id, int $amount_to_refund){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$payment_intent=\Stripe\PaymentIntent::retrieve($payment_intent_id);
-				$charge_id=$payment_intent->charges->data[0]->id;
-				$original_amount=$payment_intent->charges->data[0]->amount;
-				$already_refunded=$payment_intent->charges->data[0]->amount_refunded;
-				$remaining_refundable_amount=$original_amount-$already_refunded;
-				if($amount_to_refund>$remaining_refundable_amount){
-					log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: Refund amount greater than remaining refundable amount.');
-					return false;
-				}
-				$refund=\Stripe\Refund::create([
-					'charge'=>$charge_id,
-					'amount'=>$amount_to_refund,
-				]);
-				return $refund;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Detaches a Stripe payment method and removes its local metadata row.
-	 *
-	 * Local deletion is attempted after the Stripe detach call path, keeping the
-	 * Dataphyre payment-method table aligned with the remote customer attachment
-	 * state as closely as this legacy wrapper permits.
-	 *
-	 * @param string $payment_method_id Stripe PaymentMethod id.
-	 * @return bool True after local delete is attempted, false on SDK load failure.
-	 */
-	public static function delete_payment_method(string $payment_method_id){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$payment_method=\Stripe\PaymentMethod::retrieve($payment_method_id);
-				$payment_method->detach();
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-			}
-			sql_delete(
-				$L="stripe_payment_methods",
-				$P="WHERE id=?",
-				$V=array($payment_method_id),
-				$CC=true
-			);
-			return true;
-		}
-		return false;
-	}
-
-	/**
-	 * Retrieves a Stripe PaymentMethod.
-	 *
-	 * @param string $payment_method_id Stripe PaymentMethod id.
-	 * @return \Stripe\PaymentMethod|false PaymentMethod resource, or false on load/API failure.
-	 */
-	public static function retrieve_payment_method(string $payment_method_id){
-	  tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
 		try{
-		  $payment_method=\Stripe\PaymentMethod::retrieve($payment_method_id);
-		  return $payment_method;
-		}catch(\Exception $e){
-		  log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-		}
-	  }
-	  return false;
-	}
-
-	/**
-	 * Retrieves a Stripe PaymentIntent.
-	 *
-	 * @param string $payment_intentId Stripe PaymentIntent id.
-	 * @return \Stripe\PaymentIntent|false PaymentIntent resource, or false on load/API failure.
-	 */
-	public static function retrieve_payment_intent(string $payment_intentId){
-	  tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-		try{
-		  $payment_intent=\Stripe\PaymentIntent::retrieve($payment_intentId);
-		  return $payment_intent;
-		}catch(\Exception $e){
-		  log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-		}
-	  }
-	  return false;
-	}
-
-	/**
-	 * Captures a previously authorized Stripe PaymentIntent.
-	 *
-	 * @param string $payment_intentId Stripe PaymentIntent id.
-	 * @return \Stripe\PaymentIntent|false Captured PaymentIntent resource, or false on load/API failure.
-	 */
-	public static function capture_payment_intent(string $payment_intentId){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$payment_intent=\Stripe\PaymentIntent::retrieve($payment_intentId);
-				$payment_intent->capture();
-				return $payment_intent;
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
+			$intent=self::executeOperation('payment_intent.retrieve', [$payment_intent_id]);
+			$charge=$intent->charges->data[0] ?? null;
+			if(!is_object($charge)){
+				throw new \RuntimeException('PaymentIntent has no refundable charge.');
 			}
+			$remaining=(int)$charge->amount-(int)$charge->amount_refunded;
+			if($amount_to_refund>$remaining){
+				self::log('DataphyreStripe: Refund amount exceeds the remaining refundable amount.');
+				return false;
+			}
+			$arguments=[[
+				'charge'=>(string)$charge->id,
+				'amount'=>$amount_to_refund,
+			]];
+			if($request_options!==[]){
+				$arguments[]=$request_options;
+			}
+			return self::executeOperation('refund.create', $arguments);
+		}catch(\Throwable $exception){
+			self::logException(__FUNCTION__, $exception);
+			return false;
 		}
-		return false;
 	}
 
-	/**
-	 * Lists card payment methods attached to a Stripe Customer.
-	 *
-	 * @param string $customer_id Stripe Customer id.
-	 * @return \Stripe\Collection|false PaymentMethod collection, or false on load/API failure.
-	 */
-	public static function retrieve_all_payment_methods(string $customer_id){
-	  tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-	  if(self::load_stripe()===true){
+	public static function delete_payment_method(string $payment_method_id): bool {
+		self::trace(__FUNCTION__, func_get_args());
+		if(!self::load_stripe()){
+			return false;
+		}
 		try{
-		  $payment_methods=\Stripe\PaymentMethod::all([
-			'customer' => $customer_id,
+			$method=self::executeOperation('payment_method.retrieve', [$payment_method_id]);
+			$method->detach();
+		}catch(\Throwable $exception){
+			self::logException(__FUNCTION__, $exception);
+		}
+		self::deleteLocalPaymentMethod($payment_method_id);
+		return true;
+	}
+
+	public static function retrieve_payment_method(string $payment_method_id): mixed {
+		return self::remote(__FUNCTION__, 'payment_method.retrieve', [$payment_method_id]);
+	}
+
+	public static function retrieve_payment_intent(string $payment_intentId): mixed {
+		return self::remote(__FUNCTION__, 'payment_intent.retrieve', [$payment_intentId]);
+	}
+
+	public static function capture_payment_intent(string $payment_intentId): mixed {
+		return self::resourceAction(__FUNCTION__, 'payment_intent.retrieve', $payment_intentId, 'capture');
+	}
+
+	public static function retrieve_all_payment_methods(string $customer_id): mixed {
+		return self::remote(__FUNCTION__, 'payment_method.all', [[
+			'customer'=>$customer_id,
 			'type'=>'card',
-		  ]);
-		  return $payment_methods;
-		}catch(\Exception $e){
-		  log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
-		}
-	  }
-	  return false;
+		]]);
 	}
 
-	/**
-	 * Attaches a Stripe PaymentMethod to a Customer.
-	 *
-	 * Card declines are converted into the `card_declined` marker so callers that
-	 * already persisted local payment-method metadata can roll it back without
-	 * parsing Stripe exceptions.
-	 *
-	 * @param string $payment_method_id Stripe PaymentMethod id.
-	 * @param string $customer_id Stripe Customer id.
-	 * @return \Stripe\PaymentMethod|string|false Attached PaymentMethod, `card_declined`, or false on load/API failure.
-	 */
-	public static function attach_payment_method(string $payment_method_id, string $customer_id){
-		tracelog(__FILE__,__LINE__,__CLASS__,__FUNCTION__, $T=null, $S='function_call', $A=null);
-		if(self::load_stripe()===true){
-			try{
-				$payment_method=\Stripe\PaymentMethod::retrieve($payment_method_id);
-				$payment_method->attach(['customer'=>$customer_id]);
-				return $payment_method;
-			}catch(\Stripe\Exception\CardException $e){
-				return 'card_declined';
-			}catch(\Exception $e){
-				log_error('DataphyreStripe: '.__CLASS__.'/'.__FUNCTION__.'(): Error: '.$e->getMessage());
+	public static function attach_payment_method(string $payment_method_id, string $customer_id): mixed {
+		return self::resourceAction(
+			__FUNCTION__,
+			'payment_method.retrieve',
+			$payment_method_id,
+			'attach',
+			[['customer'=>$customer_id]],
+			'card_declined'
+		);
+	}
+
+	private static function remote(string $function, string $operation, array $arguments=[]): mixed {
+		self::trace($function, $arguments);
+		if(!self::load_stripe()){
+			return false;
+		}
+		try{
+			return self::executeOperation($operation, $arguments);
+		}catch(\Throwable $exception){
+			self::logException($function, $exception);
+			return false;
+		}
+	}
+
+	private static function resourceAction(string $function, string $operation, string $id, string $method, array $arguments=[], string|false $cardDecline=false): mixed {
+		self::trace($function, [$id, ...$arguments]);
+		if(!self::load_stripe()){
+			return false;
+		}
+		try{
+			$resource=self::executeOperation($operation, [$id]);
+			if(!is_object($resource) || !is_callable([$resource, $method])){
+				throw new \RuntimeException('Stripe resource action '.$method.' is unavailable.');
 			}
+			$resource->{$method}(...$arguments);
+			return $resource;
+		}catch(\Throwable $exception){
+			if($cardDecline!==false && self::isCardDecline($exception)){
+				return $cardDecline;
+			}
+			self::logException($function, $exception);
+			return false;
 		}
-		return false;
 	}
 
+	private static function executeOperation(string $operation, array $arguments): mixed {
+		$executor=self::$runtime['execute'] ?? [self::class, 'executeSdkOperation'];
+		if(!is_callable($executor)){
+			throw new \LogicException('Stripe operation executor must be callable.');
+		}
+		return $executor($operation, $arguments);
+	}
+
+	private static function executeSdkOperation(string $operation, array $arguments): mixed {
+		$callable=self::operationCallable($operation);
+		if(!is_callable($callable)){
+			throw new \LogicException('Unknown or unavailable Stripe SDK operation: '.$operation);
+		}
+		return $callable(...$arguments);
+	}
+
+	private static function operationCallable(string $operation): mixed {
+		$operations=is_array(self::$runtime['sdk_operations'] ?? null)
+			? self::$runtime['sdk_operations']
+			: self::SDK_OPERATIONS;
+		return $operations[$operation] ?? null;
+	}
+
+	private static function sql(string $operation, mixed ...$arguments): mixed {
+		$callable=self::$runtime['sql_'.$operation] ?? 'sql_'.$operation;
+		if(!is_callable($callable)){
+			throw new \LogicException('Stripe SQL '.$operation.' boundary must be callable.');
+		}
+		return $callable(...$arguments);
+	}
+
+	private static function deleteLocalPaymentMethod(string $id): void {
+		self::sql('delete', 'stripe_payment_methods', 'WHERE id=?', [$id], true);
+	}
+
+	private static function readApiKey(): string|false {
+		$reader=self::$runtime['get_api_key'] ?? null;
+		if($reader!==null){
+			if(!is_callable($reader)){
+				throw new \LogicException('Stripe API-key reader must be callable.');
+			}
+			$value=$reader();
+			return is_string($value) && $value!=='' ? $value : false;
+		}
+		if(!class_exists(\Stripe\Stripe::class, false)){
+			return false;
+		}
+		if(is_callable([\Stripe\Stripe::class, 'getApiKey'])){
+			$value=\Stripe\Stripe::getApiKey();
+		}elseif(property_exists(\Stripe\Stripe::class, 'api_key')){
+			$value=\Stripe\Stripe::$api_key;
+		}else{
+			$value=\Stripe\Stripe::$apiKey ?? null;
+		}
+		return is_string($value) && $value!=='' ? $value : false;
+	}
+
+	private static function writeApiKey(string $key): void {
+		$writer=self::$runtime['set_api_key'] ?? null;
+		if($writer!==null){
+			if(!is_callable($writer)){
+				throw new \LogicException('Stripe API-key writer must be callable.');
+			}
+			$writer($key);
+			return;
+		}
+		if(is_callable([\Stripe\Stripe::class, 'setApiKey'])){
+			\Stripe\Stripe::setApiKey($key);
+		}elseif(property_exists(\Stripe\Stripe::class, 'api_key')){
+			\Stripe\Stripe::$api_key=$key;
+		}else{
+			\Stripe\Stripe::$apiKey=$key;
+		}
+	}
+
+	private static function isCardDecline(\Throwable $exception): bool {
+		$policy=self::$runtime['is_card_decline'] ?? null;
+		if(is_callable($policy)){
+			return $policy($exception)===true;
+		}
+		return class_exists(\Stripe\Exception\CardException::class, false)
+			&& $exception instanceof \Stripe\Exception\CardException;
+	}
+
+	private static function trace(string $function, array $arguments=[]): void {
+		$trace=self::$runtime['trace'] ?? (function_exists('\tracelog') ? '\tracelog' : null);
+		if(is_callable($trace)){
+			$trace(__FILE__, __LINE__, __CLASS__, $function, null, 'function_call', $arguments);
+		}
+	}
+
+	private static function logException(string $function, \Throwable $exception): void {
+		self::log('DataphyreStripe: '.__CLASS__.'/'.$function.'(): Error: '.$exception->getMessage());
+	}
+
+	private static function log(string $message): void {
+		$logger=self::$runtime['log'] ?? (function_exists('\log_error') ? '\log_error' : null);
+		if(is_callable($logger)){
+			$logger($message);
+		}
+	}
+
+	private static function unavailable(string $message, ?\Throwable $exception=null): void {
+		$callback=self::$runtime['unavailable'] ?? (class_exists(core::class, false) ? [core::class, 'unavailable'] : null);
+		if(is_callable($callback)){
+			$callback(__FILE__, __LINE__, __CLASS__, __FUNCTION__, $message, 'safemode', $exception);
+		}
+	}
+
+	private static function emitWebhook(int $status, string $body, array $runtime): void {
+		$emit=$runtime['emit'] ?? self::$runtime['emit_webhook'] ?? static function(int $status, string $body): void {
+			http_response_code($status);
+			echo $body;
+		};
+		if(!is_callable($emit)){
+			throw new \LogicException('Stripe webhook emitter must be callable.');
+		}
+		$emit($status, $body);
+	}
 }
+
+/** Initializes module configuration and schema registration without hiding side effects. */
+function stripe_bootstrap(?bool $dispatch=null, array $runtime=[]): array {
+	$dispatch ??=!defined('DATAPHYRE_STRIPE_NO_DISPATCH');
+	if(!$dispatch){
+		return ['initialized'=>false,'table_registered'=>false];
+	}
+	$trace=$runtime['trace'] ?? (function_exists('\tracelog') ? '\tracelog' : null);
+	if(is_callable($trace)){
+		$trace(__FILE__, __LINE__, __CLASS__, __FUNCTION__, 'Module initialization');
+	}
+	$defaults=[
+		'test_mode'=>false,
+		'webhook_secret_key'=>false,
+		'api_secret_key_live'=>false,
+		'api_publishable_key_live'=>false,
+		'api_secret_key_test_mode'=>false,
+		'api_publishable_key_test_mode'=>false,
+		'payment_intent_minimum_amount'=>[],
+	];
+	$defineConfig=$runtime['define_config'] ?? (function_exists('\dp_define_module_config') ? '\dp_define_module_config' : null);
+	if(is_callable($defineConfig)){
+		$defineConfig('stripe', 'DP_STRIPE_CFG', $defaults);
+	}
+	$tableRegistered=false;
+	$defineTable=$runtime['define_table'] ?? (function_exists('\sql_define_table') ? '\sql_define_table' : null);
+	if(is_callable($defineTable)){
+		$defineTable('stripe_payment_methods', __DIR__.'/stripe.tables.php', 'payment_methods');
+		$tableRegistered=true;
+	}
+	stripe::resetRuntime(is_array($runtime['stripe_runtime'] ?? null) ? $runtime['stripe_runtime'] : []);
+	return ['initialized'=>true,'table_registered'=>$tableRegistered];
+}
+
+stripe_bootstrap();


### PR DESCRIPTION
## Rationale\n\nDataphyre applications need stable, documented framework capabilities for schema metadata, API route metadata/dispatch, account-isolated payment clients, secure scheduler claims, and application module policy. These are framework responsibilities independent of any product or deployment.\n\n## Scope\n\n- Publishes the reusable runtime surfaces required by modular applications.\n- Adds a framework-level capability matrix and compatibility/security rules.\n- Adds a framework unit contract test with injected fixtures; it contacts no provider and mutates no application database.\n\nNo Serve, Shopiro, tenant, catalog, receipt, fiscal, or onboarding behavior is included.