### PR TITLE
Preserve legacy module discovery by default

### DIFF
--- a/docs/RUNTIME_CAPABILITY_CONTRACTS.md
+++ b/docs/RUNTIME_CAPABILITY_CONTRACTS.md
@@ -5,6 +5,13 @@ capabilities rather than on another application's release checks. This document
 defines the small, application-neutral runtime surfaces used by modular
 installations and by framework verification.
 
+## Compatibility rule
+
+An installation with no explicit module allow-list retains legacy discovery
+semantics. A non-empty allow-list opts into strict module selection, and explicit
+denies always win. This keeps existing applications compatible while allowing a
+new application to constrain its runtime deliberately.
+
 ## Why these surfaces belong in the framework
 
 | Capability | Framework responsibility | Application responsibility |
@@ -19,14 +26,11 @@ None of these contracts names a product, tenant, catalog, receipt, or business
 workflow. They are useful to any Dataphyre application and remain optional until
 an installation enables the corresponding module or integration.
 
-## Compatibility rules
-
 Consumers must probe the documented methods and fail closed when a required
 capability is absent. Framework releases preserve the existing public facade and
 add these capability methods without requiring applications to adopt a specific
 framework consumer. Applications must not copy framework contract checks from a
-different application; the framework owns its capability documentation and
-tests.
+different application; the framework owns its capability documentation and tests.
 
 The account-isolated Stripe client never stores a secret in process-global
 configuration. The scheduler contract rejects public traffic, binds claims to a

--- a/runtime/bootstrap_config.php
+++ b/runtime/bootstrap_config.php
@@ -20,7 +20,7 @@ final class bootstrap_config {
 	 * Builds the effective bootstrap configuration for a runtime root.
 	 *
 	 * @param string $runtime_root Dataphyre runtime root directory.
-	 * @return array{project_root:string, bootstrap:array<string,mixed>, application_roots:array<int,string>, modules:array{enabled:array<string,bool>,disabled:array<string,bool>,core_implicit:bool}} Effective bootstrap payload.
+	 * @return array{project_root:string, bootstrap:array<string,mixed>, application_roots:array<int,string>, modules:array{enabled:array<string,bool>,disabled:array<string,bool>,core_implicit:bool,allow_all:bool}} Effective bootstrap payload.
 	 */
 	public static function resolve(string $runtime_root): array {
 		$runtime_root=rtrim($runtime_root, '/\\').'/';
@@ -141,10 +141,13 @@ final class bootstrap_config {
 	 * module selection.
 	 *
 	 * @param mixed $modules Raw `bootstrap.modules` payload.
-	 * @return array{enabled:array<string,bool>,disabled:array<string,bool>,core_implicit:bool} Normalized module policy.
+	 * @return array{enabled:array<string,bool>,disabled:array<string,bool>,core_implicit:bool,allow_all:bool} Normalized module policy.
 	 */
 	private static function normalize_modules(mixed $modules): array {
 		$modules=is_array($modules) ? $modules : [];
+		$explicit_enabled=array_key_exists('enabled', $modules)
+			&& is_array($modules['enabled'])
+			&& $modules['enabled']!==[];
 		$enabled=self::normalize_module_set(is_array($modules['enabled'] ?? null) ? $modules['enabled'] : []);
 		$disabled=self::normalize_module_set(is_array($modules['disabled'] ?? null) ? $modules['disabled'] : []);
 		foreach($disabled as $module=>$_){
@@ -156,6 +159,7 @@ final class bootstrap_config {
 			'enabled'=>$enabled,
 			'disabled'=>$disabled,
 			'core_implicit'=>true,
+			'allow_all'=>!$explicit_enabled,
 		];
 	}
 

--- a/runtime/modules/core/kernel/autoloader.php
+++ b/runtime/modules/core/kernel/autoloader.php
@@ -102,7 +102,9 @@ final class autoloader {
 	}
 
 	/**
-	 * Registers kernel prefixes only for flight-sheet-enabled module names.
+	 * Registers kernel prefixes for the normalized module policy. With no explicit
+	 * allow-list, the policy preserves legacy discovery and only explicit denies
+	 * suppress a module.
 	 *
 	 * @param string $modules_root Runtime modules directory.
 	 * @return void

--- a/runtime/modules/core/kernel/module_registry.php
+++ b/runtime/modules/core/kernel/module_registry.php
@@ -80,13 +80,17 @@ final class module_registry {
 	/**
 	 * Lists module names enabled by the selected application's flight sheet.
 	 *
-	 * This is a constant-time read after bootstrap normalization and does not
-	 * inspect the filesystem. An enabled name may still fail to resolve if the
-	 * package is missing, in which case presence/load methods return false.
+	 * An explicit allow-list is a constant-time policy read. With no allow-list,
+	 * legacy discovery supplies the available module names; a name may still fail
+	 * to resolve if the package is missing.
 	 *
 	 * @return array<int,string> Enabled module names.
 	 */
 	public static function enabled_modules(): array {
+		$config=self::module_config();
+		if(($config['allow_all'] ?? false)===true){
+			return self::filesystem_module_names();
+		}
 		return array_keys(self::module_config()['enabled']);
 	}
 
@@ -115,7 +119,8 @@ final class module_registry {
 			return false;
 		}
 		$config=self::module_config();
-		return isset($config['enabled'][$module]) && !isset($config['disabled'][$module]);
+		if(isset($config['disabled'][$module])) return false;
+		return ($config['allow_all'] ?? false)===true || isset($config['enabled'][$module]);
 	}
 
 	/**
@@ -271,7 +276,29 @@ final class module_registry {
 		return self::$module_config=[
 			'enabled'=>$enabled,
 			'disabled'=>$disabled,
+			'allow_all'=>($policy['allow_all'] ?? false)===true
+				|| !array_key_exists('enabled', $policy)
+				|| !is_array($policy['enabled'])
+				|| $policy['enabled']===[],
 		];
+	}
+
+	/** @return array<int,string> Module names discoverable when no allow-list is configured. */
+	private static function filesystem_module_names(): array {
+		$modules=[];
+		if(!defined('ROOTPATH')) return [];
+		foreach([ROOTPATH['common_dataphyre_runtime'] ?? '', ROOTPATH['dataphyre'] ?? ''] as $root){
+			$root=rtrim((string)$root, '/\\').'/modules';
+			if(!is_dir($root)) continue;
+			foreach(scandir($root) ?: [] as $entry){
+				$module=self::normalize_module_name((string)$entry);
+				if($module==='' || str_starts_with((string)$entry, '-') || !is_dir($root.'/'.$entry)) continue;
+				$modules[$module]=true;
+			}
+		}
+		$names=array_keys($modules);
+		sort($names);
+		return $names;
 	}
 
 	/**


### PR DESCRIPTION
The first neutral capability release made an empty module list mean core-only, which breaks existing installations that load optional modules explicitly. This follow-up preserves legacy discovery when no allow-list is supplied, keeps non-empty allow-lists strict, and keeps explicit denies authoritative. It includes the compatibility documentation and the framework contract test remains green.